### PR TITLE
Always enforce HttpVersionPolicy on WebSocket version negotiation

### DIFF
--- a/src/ReverseProxy/Forwarder/HttpForwarder.cs
+++ b/src/ReverseProxy/Forwarder/HttpForwarder.cs
@@ -370,9 +370,10 @@ internal sealed class HttpForwarder : IHttpForwarder
         var outgoingUpgrade = false;
         var outgoingConnect = false;
         var tryDowngradingH2WsOnFailure = false;
+
         if (isSpdyRequest)
         {
-            // Can only be done on HTTP/1.1, force regardless of options.
+            // Can only be done on HTTP/1.1.
             outgoingUpgrade = true;
         }
         else if (isH1WsRequest || isH2WsRequest)
@@ -384,6 +385,7 @@ internal sealed class HttpForwarder : IHttpForwarder
                 case (2, HttpVersionPolicy.RequestVersionOrHigher, _):
                     outgoingConnect = true;
                     break;
+
                 case (1, HttpVersionPolicy.RequestVersionOrHigher, true):
                 case (2, HttpVersionPolicy.RequestVersionOrLower, true):
                 case (3, HttpVersionPolicy.RequestVersionOrLower, true):
@@ -392,8 +394,7 @@ internal sealed class HttpForwarder : IHttpForwarder
                     tryDowngradingH2WsOnFailure = true;
                     break;
 #endif
-                // 1.x Lower or Exact, regardless of HTTPS
-                // Anything else without HTTPS except 2 Exact
+
                 default:
                     // Override to use HTTP/1.1, nothing else is supported.
                     outgoingUpgrade = true;
@@ -408,7 +409,9 @@ internal sealed class HttpForwarder : IHttpForwarder
             // Can only be done on HTTP/1.1, throw if disallowed by options.
             if (!http1IsAllowed)
             {
-                throw new HttpRequestException("An outgoing HTTP/1.1 Upgrade request is required to proxy this request, but is disallowed by HttpVersionPolicy.");
+                throw new HttpRequestException(isSpdyRequest
+                    ? "SPDY requests require HTTP/1.1 support, but outbound HTTP/1.1 was disallowed by HttpVersionPolicy."
+                    : "An outgoing HTTP/1.1 Upgrade request is required to proxy this request, but is disallowed by HttpVersionPolicy.");
             }
 
             destinationRequest.Version = HttpVersion.Version11;

--- a/test/ReverseProxy.FunctionalTests/Common/TestEnvironment.cs
+++ b/test/ReverseProxy.FunctionalTests/Common/TestEnvironment.cs
@@ -45,9 +45,9 @@ public class TestEnvironment
 
     public Func<ClusterConfig, RouteConfig, (ClusterConfig Cluster, RouteConfig Route)> ConfigTransformer { get; set; } = (a, b) => (a, b);
 
-    public Version DestionationHttpVersion { get; set; }
+    public Version DestinationHttpVersion { get; set; }
 
-    public HttpVersionPolicy? DestionationHttpVersionPolicy { get; set; }
+    public HttpVersionPolicy? DestinationHttpVersionPolicy { get; set; }
 
     public HttpProtocols DestinationProtocol { get; set; } = HttpProtocols.Http1AndHttp2;
 
@@ -117,8 +117,8 @@ public class TestEnvironment
                     },
                     HttpRequest = new Forwarder.ForwarderRequestConfig
                     {
-                        Version = DestionationHttpVersion,
-                        VersionPolicy = DestionationHttpVersionPolicy,
+                        Version = DestinationHttpVersion,
+                        VersionPolicy = DestinationHttpVersionPolicy,
                     }
                 };
                 (cluster, route) = ConfigTransformer(cluster, route);

--- a/test/ReverseProxy.FunctionalTests/WebSocketTests.cs
+++ b/test/ReverseProxy.FunctionalTests/WebSocketTests.cs
@@ -125,7 +125,7 @@ public class WebSocketTests
         string expectedVersion, ForwarderError? expectedProxyError, bool e2eWillFail)
     {
 #if !NET8_0_OR_GREATER
-        if (OperatingSystem.IsMacOS() && useHttpsOnDestination)
+        if (OperatingSystem.IsMacOS() && useHttpsOnDestination && destinationProtocols != HttpProtocols.Http1)
         {
             // Does not support ALPN until .NET 8
             return;
@@ -136,7 +136,6 @@ public class WebSocketTests
 
         var test = CreateTestEnvironment();
         test.ProxyProtocol = incomingVersion.Major == 1 ? HttpProtocols.Http1 : HttpProtocols.Http2;
-        test.UseHttpsOnProxy = true;
         test.DestinationProtocol = destinationProtocols;
         test.DestinationHttpVersion = requestedDestinationVersion;
         test.DestinationHttpVersionPolicy = versionPolicy;

--- a/test/ReverseProxy.Tests/Forwarder/HttpForwarderTests.cs
+++ b/test/ReverseProxy.Tests/Forwarder/HttpForwarderTests.cs
@@ -645,6 +645,38 @@ public class HttpForwarderTests
     }
 
     [Fact]
+    public async Task UpgradableSpdyRequest_DisallowedByVersionPolicy_Fails()
+    {
+        var events = TestEventListener.Collect();
+        TestLogger.Collect();
+
+        var httpContext = new DefaultHttpContext();
+        httpContext.Request.Method = "GET";
+        httpContext.Request.Headers.Upgrade = "SPDY/3.1";
+
+        var upgradeFeatureMock = new Mock<IHttpUpgradeFeature>();
+        upgradeFeatureMock.SetupGet(u => u.IsUpgradableRequest).Returns(true);
+        httpContext.Features.Set(upgradeFeatureMock.Object);
+
+        var destinationPrefix = "https://localhost:123/a/b/";
+        var sut = CreateProxy();
+        var client = MockHttpHandler.CreateClient((_, _) => throw new InvalidOperationException("Unreachable"));
+        var requestConfig = new ForwarderRequestConfig
+        {
+            Version = HttpVersion.Version20,
+            VersionPolicy = HttpVersionPolicy.RequestVersionOrHigher
+        };
+
+        var error = await sut.SendAsync(httpContext, destinationPrefix, client, requestConfig);
+
+        var ex = AssertErrorInfo<HttpRequestException>(ForwarderError.RequestCreation, StatusCodes.Status502BadGateway, error, httpContext, destinationPrefix);
+        Assert.Contains("SPDY requests require HTTP/1.1 support", ex.Message);
+
+        // Error thrown before sending the request.
+        events.AssertContainProxyStages([]);
+    }
+
+    [Fact]
     public async Task UpgradableRequest_CancelsIfIdle()
     {
         var events = TestEventListener.Collect();
@@ -2786,18 +2818,20 @@ public class HttpForwarderTests
         }
     }
 
-    private static void AssertErrorInfoAndStages<TException>(
+    private static TException AssertErrorInfoAndStages<TException>(
         ForwarderError expectedError, int expectedStatusCode,
         ForwarderError error, HttpContext context, string destinationPrefix,
         params ForwarderStage[] otherStages)
         where TException : Exception
     {
-        AssertErrorInfo<TException>(expectedError, expectedStatusCode, error, context, destinationPrefix);
+        TException exception = AssertErrorInfo<TException>(expectedError, expectedStatusCode, error, context, destinationPrefix);
 
         TestEventListener.Collect().AssertContainProxyStages([ForwarderStage.SendAsyncStart, .. otherStages]);
+
+        return exception;
     }
 
-    private static void AssertErrorInfo<TException>(
+    private static TException AssertErrorInfo<TException>(
         ForwarderError expectedError, int expectedStatusCode,
         ForwarderError error, HttpContext context, string destinationPrefix)
         where TException : Exception
@@ -2819,6 +2853,8 @@ public class HttpForwarderTests
         Assert.NotNull(log.Exception);
 
         AssertProxyStartFailedStop(TestEventListener.Collect(), destinationPrefix, context.Response.StatusCode, errorFeature.Error);
+
+        return (TException)errorFeature.Exception;
     }
 
     private static void AssertProxyStartStop(List<EventWrittenEventArgs> events, string destinationPrefix, int statusCode)


### PR DESCRIPTION
When we added HTTP/2 WebSocket support, the intention behind version selection was that we would match `SocketsHttpHandler`/`ClientWebSocket` behavior.

When the user specified `Version=2.0, Policy=RequestVersionOrHigher`, we should be attempting HTTP/2 WebSockets, regardless of whether the destination is using https or not.
Currently, we'll use HTTP/1.1 instead, which goes against the specified policy.
Aside from violating the configured policy, the current behavior is problematic when the backend service only supports HTTP/2. Instead of using H2 as requested, we'll downgrade the H1, and all requests will fail.

This change makes YARP strictly follow the version policy. If the user told us not to use HTTP/1.X, we simply shouldn't.
If the backend server happens to only support HTTP/1.X, then the request will fail, and that's a proxy misconfiguration.
