### PR TITLE
Update file headers and license file to be .NET Foundation

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) Microsoft Corporation.
+Copyright (c) .NET Foundation and Contributors
 
 All rights reserved.
 

--- a/samples/BasicYarpSample/Program.cs
+++ b/samples/BasicYarpSample/Program.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using Microsoft.AspNetCore.Builder;
 using Microsoft.Extensions.DependencyInjection;

--- a/samples/KubernetesIngress.Sample/Combined/Program.cs
+++ b/samples/KubernetesIngress.Sample/Combined/Program.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.Diagnostics;

--- a/samples/KubernetesIngress.Sample/Ingress/Program.cs
+++ b/samples/KubernetesIngress.Sample/Ingress/Program.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.Diagnostics;

--- a/samples/KubernetesIngress.Sample/Monitor/Program.cs
+++ b/samples/KubernetesIngress.Sample/Monitor/Program.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using Microsoft.AspNetCore.Builder;
 using Microsoft.Extensions.Configuration;

--- a/samples/KubernetesIngress.Sample/backend/Program.cs
+++ b/samples/KubernetesIngress.Sample/backend/Program.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Diagnostics;
 using System.Net;

--- a/samples/Prometheus/ReverseProxy.Metrics-Prometheus.Sample/Program.cs
+++ b/samples/Prometheus/ReverseProxy.Metrics-Prometheus.Sample/Program.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using Microsoft.AspNetCore.Builder;
 using Microsoft.Extensions.DependencyInjection;

--- a/samples/Prometheus/ReverseProxy.Metrics-Prometheus.Sample/PrometheusDnsMetrics.cs
+++ b/samples/Prometheus/ReverseProxy.Metrics-Prometheus.Sample/PrometheusDnsMetrics.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using Yarp.Telemetry.Consumption;
 using Prometheus;

--- a/samples/Prometheus/ReverseProxy.Metrics-Prometheus.Sample/PrometheusForwarderMetrics.cs
+++ b/samples/Prometheus/ReverseProxy.Metrics-Prometheus.Sample/PrometheusForwarderMetrics.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using Yarp.Telemetry.Consumption;
 using Prometheus;

--- a/samples/Prometheus/ReverseProxy.Metrics-Prometheus.Sample/PrometheusKestrelMetrics.cs
+++ b/samples/Prometheus/ReverseProxy.Metrics-Prometheus.Sample/PrometheusKestrelMetrics.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using Yarp.Telemetry.Consumption;
 using Prometheus;

--- a/samples/Prometheus/ReverseProxy.Metrics-Prometheus.Sample/PrometheusOutboundHttpMetrics.cs
+++ b/samples/Prometheus/ReverseProxy.Metrics-Prometheus.Sample/PrometheusOutboundHttpMetrics.cs
@@ -1,6 +1,6 @@
 
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using Yarp.Telemetry.Consumption;

--- a/samples/Prometheus/ReverseProxy.Metrics-Prometheus.Sample/PrometheusServiceExtensions.cs
+++ b/samples/Prometheus/ReverseProxy.Metrics-Prometheus.Sample/PrometheusServiceExtensions.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using Microsoft.Extensions.DependencyInjection;
 using Yarp.Telemetry.Consumption;

--- a/samples/Prometheus/ReverseProxy.Metrics-Prometheus.Sample/PrometheusSocketMetrics.cs
+++ b/samples/Prometheus/ReverseProxy.Metrics-Prometheus.Sample/PrometheusSocketMetrics.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using Yarp.Telemetry.Consumption;
 using Prometheus;

--- a/samples/ReverseProxy.Auth.Sample/Controllers/AccountController.cs
+++ b/samples/ReverseProxy.Auth.Sample/Controllers/AccountController.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Security.Claims;
 using Microsoft.AspNetCore.Authentication;

--- a/samples/ReverseProxy.Auth.Sample/Program.cs
+++ b/samples/ReverseProxy.Auth.Sample/Program.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Net.Http.Headers;
 using Microsoft.AspNetCore.Authentication;

--- a/samples/ReverseProxy.Auth.Sample/TokenService.cs
+++ b/samples/ReverseProxy.Auth.Sample/TokenService.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.Security.Claims;

--- a/samples/ReverseProxy.Code.Sample/Program.cs
+++ b/samples/ReverseProxy.Code.Sample/Program.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections.Generic;
 using System;

--- a/samples/ReverseProxy.Config.Sample/Program.cs
+++ b/samples/ReverseProxy.Config.Sample/Program.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using Microsoft.AspNetCore.Builder;
 using Microsoft.Extensions.DependencyInjection;

--- a/samples/ReverseProxy.ConfigFilter.Sample/CustomConfigFilter.cs
+++ b/samples/ReverseProxy.ConfigFilter.Sample/CustomConfigFilter.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.Collections.Generic;

--- a/samples/ReverseProxy.ConfigFilter.Sample/Program.cs
+++ b/samples/ReverseProxy.ConfigFilter.Sample/Program.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using Microsoft.AspNetCore.Builder;
 using Microsoft.Extensions.DependencyInjection;

--- a/samples/ReverseProxy.Direct.Sample/Program.cs
+++ b/samples/ReverseProxy.Direct.Sample/Program.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.Diagnostics;

--- a/samples/ReverseProxy.LetsEncrypt.Sample/Program.cs
+++ b/samples/ReverseProxy.LetsEncrypt.Sample/Program.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using Microsoft.AspNetCore.Builder;
 using Microsoft.Extensions.DependencyInjection;

--- a/samples/ReverseProxy.Metrics.Sample/ForwarderMetricsConsumer.cs
+++ b/samples/ReverseProxy.Metrics.Sample/ForwarderMetricsConsumer.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using Yarp.Telemetry.Consumption;

--- a/samples/ReverseProxy.Metrics.Sample/ForwarderTelemetryConsumer.cs
+++ b/samples/ReverseProxy.Metrics.Sample/ForwarderTelemetryConsumer.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using Yarp.ReverseProxy.Forwarder;

--- a/samples/ReverseProxy.Metrics.Sample/HttpClientTelemetryConsumer.cs
+++ b/samples/ReverseProxy.Metrics.Sample/HttpClientTelemetryConsumer.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.Net.Http;

--- a/samples/ReverseProxy.Metrics.Sample/Program.cs
+++ b/samples/ReverseProxy.Metrics.Sample/Program.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using Microsoft.AspNetCore.Builder;
 using Microsoft.Extensions.DependencyInjection;

--- a/samples/ReverseProxy.Transforms.Sample/MyTransformFactory.cs
+++ b/samples/ReverseProxy.Transforms.Sample/MyTransformFactory.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.Collections.Generic;

--- a/samples/ReverseProxy.Transforms.Sample/MyTransformProvider.cs
+++ b/samples/ReverseProxy.Transforms.Sample/MyTransformProvider.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.Net.Http;

--- a/samples/ReverseProxy.Transforms.Sample/Program.cs
+++ b/samples/ReverseProxy.Transforms.Sample/Program.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Net.Http.Headers;
 using Microsoft.AspNetCore.Authentication;

--- a/samples/ReverseProxy.Transforms.Sample/TokenService.cs
+++ b/samples/ReverseProxy.Transforms.Sample/TokenService.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Security.Claims;
 using System.Threading.Tasks;

--- a/samples/SampleServer/Controllers/HealthController.cs
+++ b/samples/SampleServer/Controllers/HealthController.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using Microsoft.AspNetCore.Mvc;
 

--- a/samples/SampleServer/Controllers/HttpController.cs
+++ b/samples/SampleServer/Controllers/HttpController.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.Collections.Generic;

--- a/samples/SampleServer/Controllers/WebSocketsController.cs
+++ b/samples/SampleServer/Controllers/WebSocketsController.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.Net.WebSockets;

--- a/samples/SampleServer/Program.cs
+++ b/samples/SampleServer/Program.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using Microsoft.AspNetCore.Builder;
 using Microsoft.Extensions.DependencyInjection;

--- a/src/Kubernetes.Controller/Caching/Endpoints.cs
+++ b/src/Kubernetes.Controller/Caching/Endpoints.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using k8s.Models;
 using System;

--- a/src/Kubernetes.Controller/Caching/ICache.cs
+++ b/src/Kubernetes.Controller/Caching/ICache.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using k8s;
 using k8s.Models;

--- a/src/Kubernetes.Controller/Caching/IngressCache.cs
+++ b/src/Kubernetes.Controller/Caching/IngressCache.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using k8s;
 using k8s.Models;

--- a/src/Kubernetes.Controller/Caching/IngressClassData.cs
+++ b/src/Kubernetes.Controller/Caching/IngressClassData.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using k8s.Models;

--- a/src/Kubernetes.Controller/Caching/IngressData.cs
+++ b/src/Kubernetes.Controller/Caching/IngressData.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using k8s.Models;
 using System;

--- a/src/Kubernetes.Controller/Caching/NamespaceCache.cs
+++ b/src/Kubernetes.Controller/Caching/NamespaceCache.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using k8s;
 using k8s.Models;

--- a/src/Kubernetes.Controller/Caching/ServiceData.cs
+++ b/src/Kubernetes.Controller/Caching/ServiceData.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using k8s.Models;
 using System;

--- a/src/Kubernetes.Controller/Certificates/CertificateHelper.cs
+++ b/src/Kubernetes.Controller/Certificates/CertificateHelper.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.Runtime.InteropServices;

--- a/src/Kubernetes.Controller/Certificates/ICertificateHelper.cs
+++ b/src/Kubernetes.Controller/Certificates/ICertificateHelper.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Security.Cryptography.X509Certificates;
 using k8s.Models;

--- a/src/Kubernetes.Controller/Certificates/IServerCertificateSelector.cs
+++ b/src/Kubernetes.Controller/Certificates/IServerCertificateSelector.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Security.Cryptography.X509Certificates;
 using Microsoft.AspNetCore.Connections;

--- a/src/Kubernetes.Controller/Certificates/ServerCertificateSelector.cs
+++ b/src/Kubernetes.Controller/Certificates/ServerCertificateSelector.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Security.Cryptography.X509Certificates;
 using Microsoft.AspNetCore.Connections;

--- a/src/Kubernetes.Controller/Client/GroupApiVersionKind.cs
+++ b/src/Kubernetes.Controller/Client/GroupApiVersionKind.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using k8s.Models;
 using System;

--- a/src/Kubernetes.Controller/Client/IIngressResourceStatusUpdater.cs
+++ b/src/Kubernetes.Controller/Client/IIngressResourceStatusUpdater.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Threading;
 using System.Threading.Tasks;

--- a/src/Kubernetes.Controller/Client/IResourceInformer.cs
+++ b/src/Kubernetes.Controller/Client/IResourceInformer.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using k8s;
 using k8s.Models;

--- a/src/Kubernetes.Controller/Client/IResourceInformerRegistration.cs
+++ b/src/Kubernetes.Controller/Client/IResourceInformerRegistration.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.Threading;

--- a/src/Kubernetes.Controller/Client/KubernetesClientOptions.cs
+++ b/src/Kubernetes.Controller/Client/KubernetesClientOptions.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using k8s;
 

--- a/src/Kubernetes.Controller/Client/ResourceInformer.cs
+++ b/src/Kubernetes.Controller/Client/ResourceInformer.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using k8s;
 using k8s.Autorest;

--- a/src/Kubernetes.Controller/Client/ResourceSelector.cs
+++ b/src/Kubernetes.Controller/Client/ResourceSelector.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using k8s;
 using k8s.Models;

--- a/src/Kubernetes.Controller/Client/V1EndpointsResourceInformer.cs
+++ b/src/Kubernetes.Controller/Client/V1EndpointsResourceInformer.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using k8s;
 using k8s.Autorest;

--- a/src/Kubernetes.Controller/Client/V1IngressClassResourceInformer.cs
+++ b/src/Kubernetes.Controller/Client/V1IngressClassResourceInformer.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using k8s;
 using k8s.Autorest;

--- a/src/Kubernetes.Controller/Client/V1IngressResourceInformer.cs
+++ b/src/Kubernetes.Controller/Client/V1IngressResourceInformer.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using k8s;
 using k8s.Autorest;

--- a/src/Kubernetes.Controller/Client/V1IngressResourceStatusUpdater.cs
+++ b/src/Kubernetes.Controller/Client/V1IngressResourceStatusUpdater.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 using System;
 using System.Linq;
 using k8s;

--- a/src/Kubernetes.Controller/Client/V1SecretResourceInformer.cs
+++ b/src/Kubernetes.Controller/Client/V1SecretResourceInformer.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using k8s;
 using k8s.Autorest;

--- a/src/Kubernetes.Controller/Client/V1ServiceResourceInformer.cs
+++ b/src/Kubernetes.Controller/Client/V1ServiceResourceInformer.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using k8s;
 using k8s.Autorest;

--- a/src/Kubernetes.Controller/ConfigProvider/IUpdateConfig.cs
+++ b/src/Kubernetes.Controller/ConfigProvider/IUpdateConfig.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections.Generic;
 using System.Threading;

--- a/src/Kubernetes.Controller/ConfigProvider/KubernetesConfigProvider.cs
+++ b/src/Kubernetes.Controller/ConfigProvider/KubernetesConfigProvider.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.Collections.Generic;

--- a/src/Kubernetes.Controller/Converters/ClusterTransfer.cs
+++ b/src/Kubernetes.Controller/Converters/ClusterTransfer.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections.Generic;
 using Yarp.ReverseProxy.Configuration;

--- a/src/Kubernetes.Controller/Converters/YarpConfigContext.cs
+++ b/src/Kubernetes.Controller/Converters/YarpConfigContext.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections.Generic;
 using System.Linq;

--- a/src/Kubernetes.Controller/Converters/YarpIngressContext.cs
+++ b/src/Kubernetes.Controller/Converters/YarpIngressContext.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections.Generic;
 using Yarp.Kubernetes.Controller.Caching;

--- a/src/Kubernetes.Controller/Converters/YarpIngressOptions.cs
+++ b/src/Kubernetes.Controller/Converters/YarpIngressOptions.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.Collections.Generic;

--- a/src/Kubernetes.Controller/Hosting/BackgroundHostedService.cs
+++ b/src/Kubernetes.Controller/Hosting/BackgroundHostedService.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;

--- a/src/Kubernetes.Controller/Hosting/HostedServiceAdapter.cs
+++ b/src/Kubernetes.Controller/Hosting/HostedServiceAdapter.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using Microsoft.Extensions.Hosting;
 using System.Threading;

--- a/src/Kubernetes.Controller/Hosting/ServiceCollectionHostedServiceAdapterExtensions.cs
+++ b/src/Kubernetes.Controller/Hosting/ServiceCollectionHostedServiceAdapterExtensions.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using Microsoft.Extensions.Hosting;
 using System.Linq;

--- a/src/Kubernetes.Controller/Management/KubernetesCoreExtensions.cs
+++ b/src/Kubernetes.Controller/Management/KubernetesCoreExtensions.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using k8s;
 using Microsoft.Extensions.Options;

--- a/src/Kubernetes.Controller/Management/KubernetesReverseProxyServiceCollectionExtensions.cs
+++ b/src/Kubernetes.Controller/Management/KubernetesReverseProxyServiceCollectionExtensions.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.Diagnostics.CodeAnalysis;

--- a/src/Kubernetes.Controller/Management/KubernetesReverseProxyWebHostBuilderExtensions.cs
+++ b/src/Kubernetes.Controller/Management/KubernetesReverseProxyWebHostBuilderExtensions.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using Microsoft.Extensions.DependencyInjection;

--- a/src/Kubernetes.Controller/NamespacedName.cs
+++ b/src/Kubernetes.Controller/NamespacedName.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using k8s;
 using k8s.Models;

--- a/src/Kubernetes.Controller/Protocol/DispatchActionResult.cs
+++ b/src/Kubernetes.Controller/Protocol/DispatchActionResult.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.Text;

--- a/src/Kubernetes.Controller/Protocol/DispatchController.cs
+++ b/src/Kubernetes.Controller/Protocol/DispatchController.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc;

--- a/src/Kubernetes.Controller/Protocol/Dispatcher.cs
+++ b/src/Kubernetes.Controller/Protocol/Dispatcher.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using Microsoft.Extensions.Logging;
 using System.Collections.Immutable;

--- a/src/Kubernetes.Controller/Protocol/IDispatchTarget.cs
+++ b/src/Kubernetes.Controller/Protocol/IDispatchTarget.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Threading;
 using System.Threading.Tasks;

--- a/src/Kubernetes.Controller/Protocol/IDispatcher.cs
+++ b/src/Kubernetes.Controller/Protocol/IDispatcher.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Threading;
 using System.Threading.Tasks;

--- a/src/Kubernetes.Controller/Protocol/Message.cs
+++ b/src/Kubernetes.Controller/Protocol/Message.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections.Generic;
 using System.Text.Json.Serialization;

--- a/src/Kubernetes.Controller/Protocol/MessageConfigProviderExtensions.cs
+++ b/src/Kubernetes.Controller/Protocol/MessageConfigProviderExtensions.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using Microsoft.Extensions.DependencyInjection;

--- a/src/Kubernetes.Controller/Protocol/Receiver.cs
+++ b/src/Kubernetes.Controller/Protocol/Receiver.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.Diagnostics;

--- a/src/Kubernetes.Controller/Protocol/ReceiverOptions.cs
+++ b/src/Kubernetes.Controller/Protocol/ReceiverOptions.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.Net.Http;

--- a/src/Kubernetes.Controller/Queues/IWorkQueue.cs
+++ b/src/Kubernetes.Controller/Queues/IWorkQueue.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.Threading;

--- a/src/Kubernetes.Controller/Queues/ProcessingRateLimitedQueue.cs
+++ b/src/Kubernetes.Controller/Queues/ProcessingRateLimitedQueue.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Threading;
 using System.Threading.Tasks;

--- a/src/Kubernetes.Controller/Queues/WorkQueue.cs
+++ b/src/Kubernetes.Controller/Queues/WorkQueue.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.Collections.Generic;

--- a/src/Kubernetes.Controller/Rate/Limit.cs
+++ b/src/Kubernetes.Controller/Rate/Limit.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.Diagnostics.CodeAnalysis;

--- a/src/Kubernetes.Controller/Rate/Limiter.cs
+++ b/src/Kubernetes.Controller/Rate/Limiter.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using Microsoft.Extensions.Internal;
 using System;

--- a/src/Kubernetes.Controller/Rate/Reservation.cs
+++ b/src/Kubernetes.Controller/Rate/Reservation.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using Microsoft.Extensions.Internal;
 using System;

--- a/src/Kubernetes.Controller/Services/IReconciler.cs
+++ b/src/Kubernetes.Controller/Services/IReconciler.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Threading;
 using System.Threading.Tasks;

--- a/src/Kubernetes.Controller/Services/IngressController.cs
+++ b/src/Kubernetes.Controller/Services/IngressController.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.Collections.Generic;

--- a/src/Kubernetes.Controller/Services/QueueItem.cs
+++ b/src/Kubernetes.Controller/Services/QueueItem.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 

--- a/src/Kubernetes.Controller/Services/ReconcileData.cs
+++ b/src/Kubernetes.Controller/Services/ReconcileData.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections.Generic;
 using Yarp.Kubernetes.Controller.Caching;

--- a/src/Kubernetes.Controller/Services/Reconciler.cs
+++ b/src/Kubernetes.Controller/Services/Reconciler.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.Linq;

--- a/src/Kubernetes.Controller/YarpOptions.cs
+++ b/src/Kubernetes.Controller/YarpOptions.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 namespace Yarp.Kubernetes.Controller;
 

--- a/src/ReverseProxy/Configuration/ActiveHealthCheckConfig.cs
+++ b/src/ReverseProxy/Configuration/ActiveHealthCheckConfig.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 

--- a/src/ReverseProxy/Configuration/AuthorizationConstants.cs
+++ b/src/ReverseProxy/Configuration/AuthorizationConstants.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 namespace Yarp.ReverseProxy.Configuration;
 

--- a/src/ReverseProxy/Configuration/ClusterConfig.cs
+++ b/src/ReverseProxy/Configuration/ClusterConfig.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.Collections.Generic;

--- a/src/ReverseProxy/Configuration/ConfigProvider/ConfigurationConfigProvider.cs
+++ b/src/ReverseProxy/Configuration/ConfigProvider/ConfigurationConfigProvider.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.Collections.Generic;

--- a/src/ReverseProxy/Configuration/ConfigProvider/ConfigurationReadingExtensions.cs
+++ b/src/ReverseProxy/Configuration/ConfigProvider/ConfigurationReadingExtensions.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.Collections.Generic;

--- a/src/ReverseProxy/Configuration/ConfigProvider/ConfigurationSnapshot.cs
+++ b/src/ReverseProxy/Configuration/ConfigProvider/ConfigurationSnapshot.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections.Generic;
 using Microsoft.Extensions.Primitives;

--- a/src/ReverseProxy/Configuration/ConfigValidator.cs
+++ b/src/ReverseProxy/Configuration/ConfigValidator.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.Collections.Generic;

--- a/src/ReverseProxy/Configuration/CorsConstants.cs
+++ b/src/ReverseProxy/Configuration/CorsConstants.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 namespace Yarp.ReverseProxy.Configuration;
 

--- a/src/ReverseProxy/Configuration/DestinationConfig.cs
+++ b/src/ReverseProxy/Configuration/DestinationConfig.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.Collections.Generic;

--- a/src/ReverseProxy/Configuration/HeaderMatchMode.cs
+++ b/src/ReverseProxy/Configuration/HeaderMatchMode.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 namespace Yarp.ReverseProxy.Configuration;
 

--- a/src/ReverseProxy/Configuration/HealthCheckConfig.cs
+++ b/src/ReverseProxy/Configuration/HealthCheckConfig.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 

--- a/src/ReverseProxy/Configuration/HttpClientConfig.cs
+++ b/src/ReverseProxy/Configuration/HttpClientConfig.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.Net.Http;

--- a/src/ReverseProxy/Configuration/IConfigChangeListener.cs
+++ b/src/ReverseProxy/Configuration/IConfigChangeListener.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.Collections.Generic;

--- a/src/ReverseProxy/Configuration/IConfigValidator.cs
+++ b/src/ReverseProxy/Configuration/IConfigValidator.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.Collections.Generic;

--- a/src/ReverseProxy/Configuration/IProxyConfig.cs
+++ b/src/ReverseProxy/Configuration/IProxyConfig.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.Collections.Generic;

--- a/src/ReverseProxy/Configuration/IProxyConfigFilter.cs
+++ b/src/ReverseProxy/Configuration/IProxyConfigFilter.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Threading;
 using System.Threading.Tasks;

--- a/src/ReverseProxy/Configuration/IProxyConfigProvider.cs
+++ b/src/ReverseProxy/Configuration/IProxyConfigProvider.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 namespace Yarp.ReverseProxy.Configuration;
 

--- a/src/ReverseProxy/Configuration/IYarpOutputCachePolicyProvider.cs
+++ b/src/ReverseProxy/Configuration/IYarpOutputCachePolicyProvider.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 #if NET7_0_OR_GREATER
 using System;

--- a/src/ReverseProxy/Configuration/IYarpRateLimiterPolicyProvider.cs
+++ b/src/ReverseProxy/Configuration/IYarpRateLimiterPolicyProvider.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 #if NET7_0_OR_GREATER
 using System;

--- a/src/ReverseProxy/Configuration/InMemoryConfigProvider.cs
+++ b/src/ReverseProxy/Configuration/InMemoryConfigProvider.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.Collections.Generic;

--- a/src/ReverseProxy/Configuration/InMemoryConfigProviderExtensions.cs
+++ b/src/ReverseProxy/Configuration/InMemoryConfigProviderExtensions.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections.Generic;
 using Yarp.ReverseProxy.Configuration;

--- a/src/ReverseProxy/Configuration/PassiveHealthCheckConfig.cs
+++ b/src/ReverseProxy/Configuration/PassiveHealthCheckConfig.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 

--- a/src/ReverseProxy/Configuration/QueryParameterMatchMode.cs
+++ b/src/ReverseProxy/Configuration/QueryParameterMatchMode.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 namespace Yarp.ReverseProxy.Configuration;
 

--- a/src/ReverseProxy/Configuration/RateLimitingConstants.cs
+++ b/src/ReverseProxy/Configuration/RateLimitingConstants.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 namespace Yarp.ReverseProxy.Configuration;
 

--- a/src/ReverseProxy/Configuration/RouteConfig.cs
+++ b/src/ReverseProxy/Configuration/RouteConfig.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.Collections.Generic;

--- a/src/ReverseProxy/Configuration/RouteHeader.cs
+++ b/src/ReverseProxy/Configuration/RouteHeader.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.Collections.Generic;

--- a/src/ReverseProxy/Configuration/RouteMatch.cs
+++ b/src/ReverseProxy/Configuration/RouteMatch.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.Collections.Generic;

--- a/src/ReverseProxy/Configuration/RouteQueryParameter.cs
+++ b/src/ReverseProxy/Configuration/RouteQueryParameter.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.Collections.Generic;

--- a/src/ReverseProxy/Configuration/SessionAffinityConfig.cs
+++ b/src/ReverseProxy/Configuration/SessionAffinityConfig.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 

--- a/src/ReverseProxy/Configuration/SessionAffinityCookieConfig.cs
+++ b/src/ReverseProxy/Configuration/SessionAffinityCookieConfig.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using Microsoft.AspNetCore.Http;

--- a/src/ReverseProxy/Configuration/TimeoutPolicyConstants.cs
+++ b/src/ReverseProxy/Configuration/TimeoutPolicyConstants.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 namespace Yarp.ReverseProxy.Configuration;
 

--- a/src/ReverseProxy/Configuration/WebProxyConfig.cs
+++ b/src/ReverseProxy/Configuration/WebProxyConfig.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 

--- a/src/ReverseProxy/Delegation/AppBuilderDelegationExtensions.cs
+++ b/src/ReverseProxy/Delegation/AppBuilderDelegationExtensions.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using Microsoft.AspNetCore.Hosting.Server;

--- a/src/ReverseProxy/Delegation/DelegationExtensions.cs
+++ b/src/ReverseProxy/Delegation/DelegationExtensions.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using Yarp.ReverseProxy.Model;
 

--- a/src/ReverseProxy/Delegation/DummyHttpSysDelegator.cs
+++ b/src/ReverseProxy/Delegation/DummyHttpSysDelegator.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 namespace Yarp.ReverseProxy.Delegation;
 

--- a/src/ReverseProxy/Delegation/HttpSysDelegator.cs
+++ b/src/ReverseProxy/Delegation/HttpSysDelegator.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.Collections.Concurrent;

--- a/src/ReverseProxy/Delegation/HttpSysDelegatorMiddleware.cs
+++ b/src/ReverseProxy/Delegation/HttpSysDelegatorMiddleware.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.Linq;

--- a/src/ReverseProxy/Forwarder/CallbackHttpClientFactory.cs
+++ b/src/ReverseProxy/Forwarder/CallbackHttpClientFactory.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.Net.Http;

--- a/src/ReverseProxy/Forwarder/DirectForwardingHttpClientProvider.cs
+++ b/src/ReverseProxy/Forwarder/DirectForwardingHttpClientProvider.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Net.Http;
 using Yarp.ReverseProxy.Configuration;

--- a/src/ReverseProxy/Forwarder/EmptyHttpContent.cs
+++ b/src/ReverseProxy/Forwarder/EmptyHttpContent.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System.IO;
 using System.Net;

--- a/src/ReverseProxy/Forwarder/ForwarderError.cs
+++ b/src/ReverseProxy/Forwarder/ForwarderError.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 namespace Yarp.ReverseProxy.Forwarder;
 

--- a/src/ReverseProxy/Forwarder/ForwarderErrorFeature.cs
+++ b/src/ReverseProxy/Forwarder/ForwarderErrorFeature.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 

--- a/src/ReverseProxy/Forwarder/ForwarderHttpClientContext.cs
+++ b/src/ReverseProxy/Forwarder/ForwarderHttpClientContext.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections.Generic;
 using System.Net.Http;

--- a/src/ReverseProxy/Forwarder/ForwarderHttpClientFactory.cs
+++ b/src/ReverseProxy/Forwarder/ForwarderHttpClientFactory.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.Diagnostics;

--- a/src/ReverseProxy/Forwarder/ForwarderMiddleware.cs
+++ b/src/ReverseProxy/Forwarder/ForwarderMiddleware.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.Diagnostics;

--- a/src/ReverseProxy/Forwarder/ForwarderRequestConfig.cs
+++ b/src/ReverseProxy/Forwarder/ForwarderRequestConfig.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.Net.Http;

--- a/src/ReverseProxy/Forwarder/ForwarderStage.cs
+++ b/src/ReverseProxy/Forwarder/ForwarderStage.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 namespace Yarp.ReverseProxy.Forwarder;
 

--- a/src/ReverseProxy/Forwarder/ForwarderTelemetry.cs
+++ b/src/ReverseProxy/Forwarder/ForwarderTelemetry.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.Diagnostics;

--- a/src/ReverseProxy/Forwarder/HttpForwarder.cs
+++ b/src/ReverseProxy/Forwarder/HttpForwarder.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.Collections.Generic;

--- a/src/ReverseProxy/Forwarder/HttpTransformer.cs
+++ b/src/ReverseProxy/Forwarder/HttpTransformer.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.Diagnostics;

--- a/src/ReverseProxy/Forwarder/IForwarderErrorFeature.cs
+++ b/src/ReverseProxy/Forwarder/IForwarderErrorFeature.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 

--- a/src/ReverseProxy/Forwarder/IForwarderHttpClientFactory.cs
+++ b/src/ReverseProxy/Forwarder/IForwarderHttpClientFactory.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Net.Http;
 

--- a/src/ReverseProxy/Forwarder/IHttpForwarder.cs
+++ b/src/ReverseProxy/Forwarder/IHttpForwarder.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Net.Http;
 using System.Threading;

--- a/src/ReverseProxy/Forwarder/IHttpForwarderExtensions.cs
+++ b/src/ReverseProxy/Forwarder/IHttpForwarderExtensions.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.Net.Http;

--- a/src/ReverseProxy/Forwarder/ProtocolHelper.cs
+++ b/src/ReverseProxy/Forwarder/ProtocolHelper.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.Diagnostics;

--- a/src/ReverseProxy/Forwarder/RequestTransformer.cs
+++ b/src/ReverseProxy/Forwarder/RequestTransformer.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.Net.Http;

--- a/src/ReverseProxy/Forwarder/RequestUtilities.cs
+++ b/src/ReverseProxy/Forwarder/RequestUtilities.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.Buffers;

--- a/src/ReverseProxy/Forwarder/ReverseProxyPropagator.cs
+++ b/src/ReverseProxy/Forwarder/ReverseProxyPropagator.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.Collections.Generic;

--- a/src/ReverseProxy/Forwarder/StreamCopier.cs
+++ b/src/ReverseProxy/Forwarder/StreamCopier.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.Buffers;

--- a/src/ReverseProxy/Forwarder/StreamCopyHttpContent.cs
+++ b/src/ReverseProxy/Forwarder/StreamCopyHttpContent.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.Diagnostics;

--- a/src/ReverseProxy/Forwarder/StreamCopyResult.cs
+++ b/src/ReverseProxy/Forwarder/StreamCopyResult.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 namespace Yarp.ReverseProxy.Forwarder;
 

--- a/src/ReverseProxy/Health/ActiveHealthCheckMonitor.Log.cs
+++ b/src/ReverseProxy/Health/ActiveHealthCheckMonitor.Log.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using Microsoft.Extensions.Logging;

--- a/src/ReverseProxy/Health/ActiveHealthCheckMonitor.cs
+++ b/src/ReverseProxy/Health/ActiveHealthCheckMonitor.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.Collections.Frozen;

--- a/src/ReverseProxy/Health/ActiveHealthCheckMonitorOptions.cs
+++ b/src/ReverseProxy/Health/ActiveHealthCheckMonitorOptions.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 

--- a/src/ReverseProxy/Health/AppBuilderHealthExtensions.cs
+++ b/src/ReverseProxy/Health/AppBuilderHealthExtensions.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using Yarp.ReverseProxy.Health;
 

--- a/src/ReverseProxy/Health/ClusterDestinationsUpdater.cs
+++ b/src/ReverseProxy/Health/ClusterDestinationsUpdater.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.Collections.Frozen;

--- a/src/ReverseProxy/Health/ConsecutiveFailuresHealthPolicy.cs
+++ b/src/ReverseProxy/Health/ConsecutiveFailuresHealthPolicy.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.Collections.Generic;

--- a/src/ReverseProxy/Health/ConsecutiveFailuresHealthPolicyOptions.cs
+++ b/src/ReverseProxy/Health/ConsecutiveFailuresHealthPolicyOptions.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 namespace Yarp.ReverseProxy.Health;
 

--- a/src/ReverseProxy/Health/DefaultProbingRequestFactory.cs
+++ b/src/ReverseProxy/Health/DefaultProbingRequestFactory.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Net;
 using System.Net.Http;

--- a/src/ReverseProxy/Health/DestinationHealthUpdater.cs
+++ b/src/ReverseProxy/Health/DestinationHealthUpdater.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.Collections.Generic;

--- a/src/ReverseProxy/Health/DestinationProbingResult.cs
+++ b/src/ReverseProxy/Health/DestinationProbingResult.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.Net.Http;

--- a/src/ReverseProxy/Health/EntityActionScheduler.cs
+++ b/src/ReverseProxy/Health/EntityActionScheduler.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.Collections.Concurrent;

--- a/src/ReverseProxy/Health/HealthCheckConstants.cs
+++ b/src/ReverseProxy/Health/HealthCheckConstants.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 namespace Yarp.ReverseProxy.Health;
 

--- a/src/ReverseProxy/Health/HealthyAndUnknownDestinationsPolicy.cs
+++ b/src/ReverseProxy/Health/HealthyAndUnknownDestinationsPolicy.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections.Generic;
 using System.Linq;

--- a/src/ReverseProxy/Health/HealthyOrPanicDestinationsPolicy.cs
+++ b/src/ReverseProxy/Health/HealthyOrPanicDestinationsPolicy.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections.Generic;
 using Yarp.ReverseProxy.Configuration;

--- a/src/ReverseProxy/Health/IActiveHealthCheckMonitor.cs
+++ b/src/ReverseProxy/Health/IActiveHealthCheckMonitor.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections.Generic;
 using System.Threading.Tasks;

--- a/src/ReverseProxy/Health/IActiveHealthCheckPolicy.cs
+++ b/src/ReverseProxy/Health/IActiveHealthCheckPolicy.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections.Generic;
 using Yarp.ReverseProxy.Model;

--- a/src/ReverseProxy/Health/IAvailableDestinationsPolicy.cs
+++ b/src/ReverseProxy/Health/IAvailableDestinationsPolicy.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections.Generic;
 using Yarp.ReverseProxy.Configuration;

--- a/src/ReverseProxy/Health/IClusterDestinationsUpdater.cs
+++ b/src/ReverseProxy/Health/IClusterDestinationsUpdater.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using Yarp.ReverseProxy.Model;
 

--- a/src/ReverseProxy/Health/IDestinationHealthUpdater.cs
+++ b/src/ReverseProxy/Health/IDestinationHealthUpdater.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.Collections.Generic;

--- a/src/ReverseProxy/Health/IPassiveHealthCheckPolicy.cs
+++ b/src/ReverseProxy/Health/IPassiveHealthCheckPolicy.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using Microsoft.AspNetCore.Http;
 using Yarp.ReverseProxy.Model;

--- a/src/ReverseProxy/Health/IProbingRequestFactory.cs
+++ b/src/ReverseProxy/Health/IProbingRequestFactory.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Net.Http;
 using Yarp.ReverseProxy.Model;

--- a/src/ReverseProxy/Health/NewActiveDestinationHealth.cs
+++ b/src/ReverseProxy/Health/NewActiveDestinationHealth.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using Yarp.ReverseProxy.Model;
 

--- a/src/ReverseProxy/Health/PassiveHealthCheckMiddleware.cs
+++ b/src/ReverseProxy/Health/PassiveHealthCheckMiddleware.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.Collections.Frozen;

--- a/src/ReverseProxy/Health/TransportFailureRateHealthPolicy.cs
+++ b/src/ReverseProxy/Health/TransportFailureRateHealthPolicy.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.Collections.Generic;

--- a/src/ReverseProxy/Health/TransportFailureRateHealthPolicyOptions.cs
+++ b/src/ReverseProxy/Health/TransportFailureRateHealthPolicyOptions.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 

--- a/src/ReverseProxy/Limits/LimitsMiddleware.cs
+++ b/src/ReverseProxy/Limits/LimitsMiddleware.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.Threading.Tasks;

--- a/src/ReverseProxy/LoadBalancing/AppBuilderLoadBalancingExtensions.cs
+++ b/src/ReverseProxy/LoadBalancing/AppBuilderLoadBalancingExtensions.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using Yarp.ReverseProxy.LoadBalancing;
 

--- a/src/ReverseProxy/LoadBalancing/FirstLoadBalancingPolicy.cs
+++ b/src/ReverseProxy/LoadBalancing/FirstLoadBalancingPolicy.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.Collections.Generic;

--- a/src/ReverseProxy/LoadBalancing/ILoadBalancingPolicy.cs
+++ b/src/ReverseProxy/LoadBalancing/ILoadBalancingPolicy.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections.Generic;
 using Microsoft.AspNetCore.Http;

--- a/src/ReverseProxy/LoadBalancing/LeastRequestsLoadBalancingPolicy.cs
+++ b/src/ReverseProxy/LoadBalancing/LeastRequestsLoadBalancingPolicy.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections.Generic;
 using Microsoft.AspNetCore.Http;

--- a/src/ReverseProxy/LoadBalancing/LoadBalancingMiddleware.cs
+++ b/src/ReverseProxy/LoadBalancing/LoadBalancingMiddleware.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.Collections.Frozen;

--- a/src/ReverseProxy/LoadBalancing/LoadBalancingPolicies.cs
+++ b/src/ReverseProxy/LoadBalancing/LoadBalancingPolicies.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 namespace Yarp.ReverseProxy.LoadBalancing;
 

--- a/src/ReverseProxy/LoadBalancing/PowerOfTwoChoicesLoadBalancingPolicy.cs
+++ b/src/ReverseProxy/LoadBalancing/PowerOfTwoChoicesLoadBalancingPolicy.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections.Generic;
 using Microsoft.AspNetCore.Http;

--- a/src/ReverseProxy/LoadBalancing/RandomLoadBalancingPolicy.cs
+++ b/src/ReverseProxy/LoadBalancing/RandomLoadBalancingPolicy.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections.Generic;
 using Microsoft.AspNetCore.Http;

--- a/src/ReverseProxy/LoadBalancing/RoundRobinLoadBalancingPolicy.cs
+++ b/src/ReverseProxy/LoadBalancing/RoundRobinLoadBalancingPolicy.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections.Generic;
 using System.Runtime.CompilerServices;

--- a/src/ReverseProxy/Management/IProxyStateLookup.cs
+++ b/src/ReverseProxy/Management/IProxyStateLookup.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;

--- a/src/ReverseProxy/Management/IReverseProxyBuilder.cs
+++ b/src/ReverseProxy/Management/IReverseProxyBuilder.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 namespace Microsoft.Extensions.DependencyInjection;
 

--- a/src/ReverseProxy/Management/IReverseProxyBuilderExtensions.cs
+++ b/src/ReverseProxy/Management/IReverseProxyBuilderExtensions.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Linq;
 using Microsoft.AspNetCore.Routing;

--- a/src/ReverseProxy/Management/ProxyConfigManager.cs
+++ b/src/ReverseProxy/Management/ProxyConfigManager.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.Collections.Concurrent;

--- a/src/ReverseProxy/Management/ReverseProxyBuilder.cs
+++ b/src/ReverseProxy/Management/ReverseProxyBuilder.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using Microsoft.Extensions.DependencyInjection;

--- a/src/ReverseProxy/Management/ReverseProxyServiceCollectionExtensions.cs
+++ b/src/ReverseProxy/Management/ReverseProxyServiceCollectionExtensions.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.Diagnostics.CodeAnalysis;

--- a/src/ReverseProxy/Model/ClusterDestinationsState.cs
+++ b/src/ReverseProxy/Model/ClusterDestinationsState.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.Collections.Generic;

--- a/src/ReverseProxy/Model/ClusterModel.cs
+++ b/src/ReverseProxy/Model/ClusterModel.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.Net.Http;

--- a/src/ReverseProxy/Model/ClusterState.cs
+++ b/src/ReverseProxy/Model/ClusterState.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.Collections.Concurrent;

--- a/src/ReverseProxy/Model/DestinationHealth.cs
+++ b/src/ReverseProxy/Model/DestinationHealth.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 namespace Yarp.ReverseProxy.Model;
 

--- a/src/ReverseProxy/Model/DestinationHealthState.cs
+++ b/src/ReverseProxy/Model/DestinationHealthState.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 namespace Yarp.ReverseProxy.Model;
 

--- a/src/ReverseProxy/Model/DestinationModel.cs
+++ b/src/ReverseProxy/Model/DestinationModel.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using Yarp.ReverseProxy.Configuration;

--- a/src/ReverseProxy/Model/DestinationState.cs
+++ b/src/ReverseProxy/Model/DestinationState.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.Collections;

--- a/src/ReverseProxy/Model/HttpContextFeaturesExtensions.cs
+++ b/src/ReverseProxy/Model/HttpContextFeaturesExtensions.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using Yarp.ReverseProxy.Model;

--- a/src/ReverseProxy/Model/IClusterChangeListener.cs
+++ b/src/ReverseProxy/Model/IClusterChangeListener.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 namespace Yarp.ReverseProxy.Model;
 

--- a/src/ReverseProxy/Model/IReverseProxyApplicationBuilder.cs
+++ b/src/ReverseProxy/Model/IReverseProxyApplicationBuilder.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 namespace Microsoft.AspNetCore.Builder;
 

--- a/src/ReverseProxy/Model/IReverseProxyFeature.cs
+++ b/src/ReverseProxy/Model/IReverseProxyFeature.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections.Generic;
 

--- a/src/ReverseProxy/Model/ProxyPipelineInitializerMiddleware.cs
+++ b/src/ReverseProxy/Model/ProxyPipelineInitializerMiddleware.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.Diagnostics;

--- a/src/ReverseProxy/Model/ReverseProxyApplicationBuilder.cs
+++ b/src/ReverseProxy/Model/ReverseProxyApplicationBuilder.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.Collections.Generic;

--- a/src/ReverseProxy/Model/ReverseProxyFeature.cs
+++ b/src/ReverseProxy/Model/ReverseProxyFeature.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.Collections.Generic;

--- a/src/ReverseProxy/Model/RouteModel.cs
+++ b/src/ReverseProxy/Model/RouteModel.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using Yarp.ReverseProxy.Configuration;

--- a/src/ReverseProxy/Model/RouteState.cs
+++ b/src/ReverseProxy/Model/RouteState.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using Microsoft.AspNetCore.Http;

--- a/src/ReverseProxy/Routing/DirectForwardingIEndpointRouteBuilderExtensions.cs
+++ b/src/ReverseProxy/Routing/DirectForwardingIEndpointRouteBuilderExtensions.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.Diagnostics.CodeAnalysis;

--- a/src/ReverseProxy/Routing/HeaderMatcher.cs
+++ b/src/ReverseProxy/Routing/HeaderMatcher.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.Collections.Generic;

--- a/src/ReverseProxy/Routing/HeaderMatcherPolicy.cs
+++ b/src/ReverseProxy/Routing/HeaderMatcherPolicy.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.Collections.Generic;

--- a/src/ReverseProxy/Routing/HeaderMetadata.cs
+++ b/src/ReverseProxy/Routing/HeaderMetadata.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.Collections.Generic;

--- a/src/ReverseProxy/Routing/IHeaderMetadata.cs
+++ b/src/ReverseProxy/Routing/IHeaderMetadata.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 namespace Yarp.ReverseProxy.Routing;
 

--- a/src/ReverseProxy/Routing/IQueryParameterMetadata.cs
+++ b/src/ReverseProxy/Routing/IQueryParameterMetadata.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 namespace Yarp.ReverseProxy.Routing;
 

--- a/src/ReverseProxy/Routing/ProxyEndpointFactory.cs
+++ b/src/ReverseProxy/Routing/ProxyEndpointFactory.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.Collections.Generic;

--- a/src/ReverseProxy/Routing/QueryParameterMatcher.cs
+++ b/src/ReverseProxy/Routing/QueryParameterMatcher.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.Collections.Generic;

--- a/src/ReverseProxy/Routing/QueryParameterMatcherPolicy.cs
+++ b/src/ReverseProxy/Routing/QueryParameterMatcherPolicy.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.Collections.Generic;

--- a/src/ReverseProxy/Routing/QueryParameterMetadata.cs
+++ b/src/ReverseProxy/Routing/QueryParameterMetadata.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.Collections.Generic;

--- a/src/ReverseProxy/Routing/ReverseProxyConventionBuilder.cs
+++ b/src/ReverseProxy/Routing/ReverseProxyConventionBuilder.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.Collections.Generic;

--- a/src/ReverseProxy/Routing/ReverseProxyIEndpointRouteBuilderExtensions.cs
+++ b/src/ReverseProxy/Routing/ReverseProxyIEndpointRouteBuilderExtensions.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.Linq;

--- a/src/ReverseProxy/ServiceDiscovery/DnsDestinationResolver.cs
+++ b/src/ReverseProxy/ServiceDiscovery/DnsDestinationResolver.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.Collections.Generic;

--- a/src/ReverseProxy/ServiceDiscovery/DnsDestinationResolverOptions.cs
+++ b/src/ReverseProxy/ServiceDiscovery/DnsDestinationResolverOptions.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.Net.Sockets;

--- a/src/ReverseProxy/ServiceDiscovery/IDestinationResolver.cs
+++ b/src/ReverseProxy/ServiceDiscovery/IDestinationResolver.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections.Generic;
 using System.Threading;

--- a/src/ReverseProxy/ServiceDiscovery/NoOpDestinationResolver.cs
+++ b/src/ReverseProxy/ServiceDiscovery/NoOpDestinationResolver.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections.Generic;
 using System.Threading;

--- a/src/ReverseProxy/ServiceDiscovery/ResolvedDestinationCollection.cs
+++ b/src/ReverseProxy/ServiceDiscovery/ResolvedDestinationCollection.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections.Generic;
 using Microsoft.Extensions.Primitives;

--- a/src/ReverseProxy/SessionAffinity/AffinitizeTransform.cs
+++ b/src/ReverseProxy/SessionAffinity/AffinitizeTransform.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.Diagnostics;

--- a/src/ReverseProxy/SessionAffinity/AffinitizeTransformProvider.cs
+++ b/src/ReverseProxy/SessionAffinity/AffinitizeTransformProvider.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.Collections.Frozen;

--- a/src/ReverseProxy/SessionAffinity/AffinityHelpers.cs
+++ b/src/ReverseProxy/SessionAffinity/AffinityHelpers.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using Microsoft.AspNetCore.Http;

--- a/src/ReverseProxy/SessionAffinity/AffinityResult.cs
+++ b/src/ReverseProxy/SessionAffinity/AffinityResult.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections.Generic;
 using Yarp.ReverseProxy.Model;

--- a/src/ReverseProxy/SessionAffinity/AffinityStatus.cs
+++ b/src/ReverseProxy/SessionAffinity/AffinityStatus.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 namespace Yarp.ReverseProxy.SessionAffinity;
 

--- a/src/ReverseProxy/SessionAffinity/AppBuilderSessionAffinityExtensions.cs
+++ b/src/ReverseProxy/SessionAffinity/AppBuilderSessionAffinityExtensions.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using Yarp.ReverseProxy.SessionAffinity;
 

--- a/src/ReverseProxy/SessionAffinity/ArrCookieSessionAffinityPolicy.cs
+++ b/src/ReverseProxy/SessionAffinity/ArrCookieSessionAffinityPolicy.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.Runtime.CompilerServices;

--- a/src/ReverseProxy/SessionAffinity/BaseEncryptedSessionAffinityPolicy.cs
+++ b/src/ReverseProxy/SessionAffinity/BaseEncryptedSessionAffinityPolicy.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.Collections.Generic;

--- a/src/ReverseProxy/SessionAffinity/BaseHashCookieSessionAffinityPolicy.cs
+++ b/src/ReverseProxy/SessionAffinity/BaseHashCookieSessionAffinityPolicy.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.Collections.Generic;

--- a/src/ReverseProxy/SessionAffinity/CookieSessionAffinityPolicy.cs
+++ b/src/ReverseProxy/SessionAffinity/CookieSessionAffinityPolicy.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using Microsoft.AspNetCore.DataProtection;

--- a/src/ReverseProxy/SessionAffinity/CustomHeaderSessionAffinityPolicy.cs
+++ b/src/ReverseProxy/SessionAffinity/CustomHeaderSessionAffinityPolicy.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using Microsoft.AspNetCore.DataProtection;

--- a/src/ReverseProxy/SessionAffinity/HashCookieSessionAffinityPolicy.cs
+++ b/src/ReverseProxy/SessionAffinity/HashCookieSessionAffinityPolicy.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.IO.Hashing;

--- a/src/ReverseProxy/SessionAffinity/IAffinityFailurePolicy.cs
+++ b/src/ReverseProxy/SessionAffinity/IAffinityFailurePolicy.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;

--- a/src/ReverseProxy/SessionAffinity/ISessionAffinityPolicy.cs
+++ b/src/ReverseProxy/SessionAffinity/ISessionAffinityPolicy.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections.Generic;
 using System.Threading;

--- a/src/ReverseProxy/SessionAffinity/Log.cs
+++ b/src/ReverseProxy/SessionAffinity/Log.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using Microsoft.Extensions.Logging;

--- a/src/ReverseProxy/SessionAffinity/RedistributeAffinityFailurePolicy.cs
+++ b/src/ReverseProxy/SessionAffinity/RedistributeAffinityFailurePolicy.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.Threading.Tasks;

--- a/src/ReverseProxy/SessionAffinity/Return503ErrorAffinityFailurePolicy.cs
+++ b/src/ReverseProxy/SessionAffinity/Return503ErrorAffinityFailurePolicy.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.Threading.Tasks;

--- a/src/ReverseProxy/SessionAffinity/SessionAffinityConstants.cs
+++ b/src/ReverseProxy/SessionAffinity/SessionAffinityConstants.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 namespace Yarp.ReverseProxy.SessionAffinity;
 

--- a/src/ReverseProxy/SessionAffinity/SessionAffinityMiddleware.cs
+++ b/src/ReverseProxy/SessionAffinity/SessionAffinityMiddleware.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.Collections.Frozen;

--- a/src/ReverseProxy/Transforms/Builder/ActionTransformProvider.cs
+++ b/src/ReverseProxy/Transforms/Builder/ActionTransformProvider.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 

--- a/src/ReverseProxy/Transforms/Builder/ITransformBuilder.cs
+++ b/src/ReverseProxy/Transforms/Builder/ITransformBuilder.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.Collections.Generic;

--- a/src/ReverseProxy/Transforms/Builder/ITransformFactory.cs
+++ b/src/ReverseProxy/Transforms/Builder/ITransformFactory.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections.Generic;
 

--- a/src/ReverseProxy/Transforms/Builder/ITransformProvider.cs
+++ b/src/ReverseProxy/Transforms/Builder/ITransformProvider.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 namespace Yarp.ReverseProxy.Transforms.Builder;
 

--- a/src/ReverseProxy/Transforms/Builder/StructuredTransformer.cs
+++ b/src/ReverseProxy/Transforms/Builder/StructuredTransformer.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.Collections.Generic;

--- a/src/ReverseProxy/Transforms/Builder/TransformBuilder.cs
+++ b/src/ReverseProxy/Transforms/Builder/TransformBuilder.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.Collections.Generic;

--- a/src/ReverseProxy/Transforms/Builder/TransformBuilderContext.cs
+++ b/src/ReverseProxy/Transforms/Builder/TransformBuilderContext.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.Collections.Generic;

--- a/src/ReverseProxy/Transforms/Builder/TransformClusterValidationContext.cs
+++ b/src/ReverseProxy/Transforms/Builder/TransformClusterValidationContext.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.Collections.Generic;

--- a/src/ReverseProxy/Transforms/Builder/TransformHelpers.cs
+++ b/src/ReverseProxy/Transforms/Builder/TransformHelpers.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.Collections.Generic;

--- a/src/ReverseProxy/Transforms/Builder/TransformRouteValidationContext.cs
+++ b/src/ReverseProxy/Transforms/Builder/TransformRouteValidationContext.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.Collections.Generic;

--- a/src/ReverseProxy/Transforms/ForwardedTransformActions.cs
+++ b/src/ReverseProxy/Transforms/ForwardedTransformActions.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 namespace Yarp.ReverseProxy.Transforms;
 

--- a/src/ReverseProxy/Transforms/ForwardedTransformExtensions.cs
+++ b/src/ReverseProxy/Transforms/ForwardedTransformExtensions.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections.Generic;
 using Microsoft.Extensions.DependencyInjection;

--- a/src/ReverseProxy/Transforms/ForwardedTransformFactory.cs
+++ b/src/ReverseProxy/Transforms/ForwardedTransformFactory.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.Collections.Generic;

--- a/src/ReverseProxy/Transforms/HttpMethodChangeTransform.cs
+++ b/src/ReverseProxy/Transforms/HttpMethodChangeTransform.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.Net.Http;

--- a/src/ReverseProxy/Transforms/HttpMethodTransformExtensions.cs
+++ b/src/ReverseProxy/Transforms/HttpMethodTransformExtensions.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using Yarp.ReverseProxy.Configuration;
 using Yarp.ReverseProxy.Transforms.Builder;

--- a/src/ReverseProxy/Transforms/HttpMethodTransformFactory.cs
+++ b/src/ReverseProxy/Transforms/HttpMethodTransformFactory.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.Collections.Generic;

--- a/src/ReverseProxy/Transforms/NodeFormat.cs
+++ b/src/ReverseProxy/Transforms/NodeFormat.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 namespace Yarp.ReverseProxy.Transforms;
 

--- a/src/ReverseProxy/Transforms/PathRouteValuesTransform.cs
+++ b/src/ReverseProxy/Transforms/PathRouteValuesTransform.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.Diagnostics.CodeAnalysis;

--- a/src/ReverseProxy/Transforms/PathStringTransform.cs
+++ b/src/ReverseProxy/Transforms/PathStringTransform.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.Threading.Tasks;

--- a/src/ReverseProxy/Transforms/PathTransformExtensions.cs
+++ b/src/ReverseProxy/Transforms/PathTransformExtensions.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.Diagnostics.CodeAnalysis;

--- a/src/ReverseProxy/Transforms/PathTransformFactory.cs
+++ b/src/ReverseProxy/Transforms/PathTransformFactory.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.Collections.Generic;

--- a/src/ReverseProxy/Transforms/QueryParameterFromRouteTransform.cs
+++ b/src/ReverseProxy/Transforms/QueryParameterFromRouteTransform.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 

--- a/src/ReverseProxy/Transforms/QueryParameterFromStaticTransform.cs
+++ b/src/ReverseProxy/Transforms/QueryParameterFromStaticTransform.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 

--- a/src/ReverseProxy/Transforms/QueryParameterRemoveTransform.cs
+++ b/src/ReverseProxy/Transforms/QueryParameterRemoveTransform.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.Threading.Tasks;

--- a/src/ReverseProxy/Transforms/QueryParameterTransform.cs
+++ b/src/ReverseProxy/Transforms/QueryParameterTransform.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.Threading.Tasks;

--- a/src/ReverseProxy/Transforms/QueryTransformContext.cs
+++ b/src/ReverseProxy/Transforms/QueryTransformContext.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.Collections.Generic;

--- a/src/ReverseProxy/Transforms/QueryTransformExtensions.cs
+++ b/src/ReverseProxy/Transforms/QueryTransformExtensions.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using Yarp.ReverseProxy.Configuration;
 using Yarp.ReverseProxy.Transforms.Builder;

--- a/src/ReverseProxy/Transforms/QueryTransformFactory.cs
+++ b/src/ReverseProxy/Transforms/QueryTransformFactory.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.Collections.Generic;

--- a/src/ReverseProxy/Transforms/RequestFuncTransform.cs
+++ b/src/ReverseProxy/Transforms/RequestFuncTransform.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.Threading.Tasks;

--- a/src/ReverseProxy/Transforms/RequestHeaderClientCertTransform.cs
+++ b/src/ReverseProxy/Transforms/RequestHeaderClientCertTransform.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.Threading.Tasks;

--- a/src/ReverseProxy/Transforms/RequestHeaderForwardedTransform.cs
+++ b/src/ReverseProxy/Transforms/RequestHeaderForwardedTransform.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.Diagnostics;

--- a/src/ReverseProxy/Transforms/RequestHeaderOriginalHostTransform.cs
+++ b/src/ReverseProxy/Transforms/RequestHeaderOriginalHostTransform.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.Threading.Tasks;

--- a/src/ReverseProxy/Transforms/RequestHeaderRemoveTransform.cs
+++ b/src/ReverseProxy/Transforms/RequestHeaderRemoveTransform.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.Threading.Tasks;

--- a/src/ReverseProxy/Transforms/RequestHeaderValueTransform.cs
+++ b/src/ReverseProxy/Transforms/RequestHeaderValueTransform.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.Threading.Tasks;

--- a/src/ReverseProxy/Transforms/RequestHeaderXForwardedForTransform.cs
+++ b/src/ReverseProxy/Transforms/RequestHeaderXForwardedForTransform.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.Diagnostics;

--- a/src/ReverseProxy/Transforms/RequestHeaderXForwardedHostTransform.cs
+++ b/src/ReverseProxy/Transforms/RequestHeaderXForwardedHostTransform.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.Diagnostics;

--- a/src/ReverseProxy/Transforms/RequestHeaderXForwardedPrefixTransform.cs
+++ b/src/ReverseProxy/Transforms/RequestHeaderXForwardedPrefixTransform.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.Diagnostics;

--- a/src/ReverseProxy/Transforms/RequestHeaderXForwardedProtoTransform.cs
+++ b/src/ReverseProxy/Transforms/RequestHeaderXForwardedProtoTransform.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.Diagnostics;

--- a/src/ReverseProxy/Transforms/RequestHeadersAllowedTransform.cs
+++ b/src/ReverseProxy/Transforms/RequestHeadersAllowedTransform.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.Collections.Frozen;

--- a/src/ReverseProxy/Transforms/RequestHeadersTransformExtensions.cs
+++ b/src/ReverseProxy/Transforms/RequestHeadersTransformExtensions.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using Yarp.ReverseProxy.Configuration;
 using Yarp.ReverseProxy.Transforms.Builder;

--- a/src/ReverseProxy/Transforms/RequestHeadersTransformFactory.cs
+++ b/src/ReverseProxy/Transforms/RequestHeadersTransformFactory.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.Collections.Generic;

--- a/src/ReverseProxy/Transforms/RequestTransform.cs
+++ b/src/ReverseProxy/Transforms/RequestTransform.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.Threading.Tasks;

--- a/src/ReverseProxy/Transforms/RequestTransformContext.cs
+++ b/src/ReverseProxy/Transforms/RequestTransformContext.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Net.Http;
 using System.Threading;

--- a/src/ReverseProxy/Transforms/ResponseCondition.cs
+++ b/src/ReverseProxy/Transforms/ResponseCondition.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 namespace Yarp.ReverseProxy.Transforms;
 

--- a/src/ReverseProxy/Transforms/ResponseFuncTransform.cs
+++ b/src/ReverseProxy/Transforms/ResponseFuncTransform.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.Threading.Tasks;

--- a/src/ReverseProxy/Transforms/ResponseHeaderRemoveTransform.cs
+++ b/src/ReverseProxy/Transforms/ResponseHeaderRemoveTransform.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.Threading.Tasks;

--- a/src/ReverseProxy/Transforms/ResponseHeaderValueTransform.cs
+++ b/src/ReverseProxy/Transforms/ResponseHeaderValueTransform.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.Threading.Tasks;

--- a/src/ReverseProxy/Transforms/ResponseHeadersAllowedTransform.cs
+++ b/src/ReverseProxy/Transforms/ResponseHeadersAllowedTransform.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.Collections.Frozen;

--- a/src/ReverseProxy/Transforms/ResponseTrailerRemoveTransform.cs
+++ b/src/ReverseProxy/Transforms/ResponseTrailerRemoveTransform.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.Diagnostics;

--- a/src/ReverseProxy/Transforms/ResponseTrailerValueTransform.cs
+++ b/src/ReverseProxy/Transforms/ResponseTrailerValueTransform.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.Threading.Tasks;

--- a/src/ReverseProxy/Transforms/ResponseTrailersAllowedTransform.cs
+++ b/src/ReverseProxy/Transforms/ResponseTrailersAllowedTransform.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.Collections.Frozen;

--- a/src/ReverseProxy/Transforms/ResponseTrailersFuncTransform.cs
+++ b/src/ReverseProxy/Transforms/ResponseTrailersFuncTransform.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.Threading.Tasks;

--- a/src/ReverseProxy/Transforms/ResponseTrailersTransform.cs
+++ b/src/ReverseProxy/Transforms/ResponseTrailersTransform.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.Diagnostics;

--- a/src/ReverseProxy/Transforms/ResponseTrailersTransformContext.cs
+++ b/src/ReverseProxy/Transforms/ResponseTrailersTransformContext.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Net.Http;
 using System.Threading;

--- a/src/ReverseProxy/Transforms/ResponseTransform.cs
+++ b/src/ReverseProxy/Transforms/ResponseTransform.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.Threading.Tasks;

--- a/src/ReverseProxy/Transforms/ResponseTransformContext.cs
+++ b/src/ReverseProxy/Transforms/ResponseTransformContext.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Net.Http;
 using System.Threading;

--- a/src/ReverseProxy/Transforms/ResponseTransformExtensions.cs
+++ b/src/ReverseProxy/Transforms/ResponseTransformExtensions.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using Yarp.ReverseProxy.Configuration;
 using Yarp.ReverseProxy.Transforms.Builder;

--- a/src/ReverseProxy/Transforms/ResponseTransformFactory.cs
+++ b/src/ReverseProxy/Transforms/ResponseTransformFactory.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.Collections.Generic;

--- a/src/ReverseProxy/Transforms/RouteConfigTransformExtensions.cs
+++ b/src/ReverseProxy/Transforms/RouteConfigTransformExtensions.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.Collections.Generic;

--- a/src/ReverseProxy/Transforms/TransformBuilderContextFuncExtensions.cs
+++ b/src/ReverseProxy/Transforms/TransformBuilderContextFuncExtensions.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 
 using System;

--- a/src/ReverseProxy/Utilities/ActivityCancellationTokenSource.cs
+++ b/src/ReverseProxy/Utilities/ActivityCancellationTokenSource.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.Collections.Concurrent;

--- a/src/ReverseProxy/Utilities/AtomicCounter.cs
+++ b/src/ReverseProxy/Utilities/AtomicCounter.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Threading;
 

--- a/src/ReverseProxy/Utilities/CaseInsensitiveEqualHelper.cs
+++ b/src/ReverseProxy/Utilities/CaseInsensitiveEqualHelper.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.Collections.Generic;

--- a/src/ReverseProxy/Utilities/CaseSensitiveEqualHelper.cs
+++ b/src/ReverseProxy/Utilities/CaseSensitiveEqualHelper.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.Collections.Generic;

--- a/src/ReverseProxy/Utilities/CollectionEqualityHelper.cs
+++ b/src/ReverseProxy/Utilities/CollectionEqualityHelper.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.Collections.Generic;

--- a/src/ReverseProxy/Utilities/ConcurrentDictionaryExtensions.cs
+++ b/src/ReverseProxy/Utilities/ConcurrentDictionaryExtensions.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections.Concurrent;
 using System.Collections.Generic;

--- a/src/ReverseProxy/Utilities/DelegatingStream.cs
+++ b/src/ReverseProxy/Utilities/DelegatingStream.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.Diagnostics;

--- a/src/ReverseProxy/Utilities/EventIds.cs
+++ b/src/ReverseProxy/Utilities/EventIds.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using Microsoft.Extensions.Logging;
 

--- a/src/ReverseProxy/Utilities/IClock.cs
+++ b/src/ReverseProxy/Utilities/IClock.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.Threading;

--- a/src/ReverseProxy/Utilities/IRandomFactory.cs
+++ b/src/ReverseProxy/Utilities/IRandomFactory.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 

--- a/src/ReverseProxy/Utilities/NullRandomFactory.cs
+++ b/src/ReverseProxy/Utilities/NullRandomFactory.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 

--- a/src/ReverseProxy/Utilities/Observability.cs
+++ b/src/ReverseProxy/Utilities/Observability.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Diagnostics;
 using Microsoft.AspNetCore.Http;

--- a/src/ReverseProxy/Utilities/ParsedMetadataEntry.cs
+++ b/src/ReverseProxy/Utilities/ParsedMetadataEntry.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using Yarp.ReverseProxy.Model;

--- a/src/ReverseProxy/Utilities/RandomFactory.cs
+++ b/src/ReverseProxy/Utilities/RandomFactory.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 

--- a/src/ReverseProxy/Utilities/ServiceLookupHelper.cs
+++ b/src/ReverseProxy/Utilities/ServiceLookupHelper.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.Collections.Frozen;

--- a/src/ReverseProxy/Utilities/SkipLocalsInit.cs
+++ b/src/ReverseProxy/Utilities/SkipLocalsInit.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 // Used to indicate to the compiler that the .locals init flag should not be set in method headers.
 [module: System.Runtime.CompilerServices.SkipLocalsInit]

--- a/src/ReverseProxy/Utilities/StringSyntaxAttribute.cs
+++ b/src/ReverseProxy/Utilities/StringSyntaxAttribute.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 namespace System.Diagnostics.CodeAnalysis
 {

--- a/src/ReverseProxy/Utilities/TaskUtilities.cs
+++ b/src/ReverseProxy/Utilities/TaskUtilities.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Threading.Tasks;
 

--- a/src/ReverseProxy/Utilities/ValueStopwatch.cs
+++ b/src/ReverseProxy/Utilities/ValueStopwatch.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.Diagnostics;

--- a/src/ReverseProxy/Utilities/ValueStringBuilder.cs
+++ b/src/ReverseProxy/Utilities/ValueStringBuilder.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.Buffers;

--- a/src/ReverseProxy/WebSocketsTelemetry/HttpConnectFeatureWrapper.cs
+++ b/src/ReverseProxy/WebSocketsTelemetry/HttpConnectFeatureWrapper.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 #if NET7_0_OR_GREATER
 

--- a/src/ReverseProxy/WebSocketsTelemetry/HttpUpgradeFeatureWrapper.cs
+++ b/src/ReverseProxy/WebSocketsTelemetry/HttpUpgradeFeatureWrapper.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.Diagnostics;

--- a/src/ReverseProxy/WebSocketsTelemetry/WebSocketCloseReason.cs
+++ b/src/ReverseProxy/WebSocketsTelemetry/WebSocketCloseReason.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 namespace Yarp.ReverseProxy.WebSocketsTelemetry;
 

--- a/src/ReverseProxy/WebSocketsTelemetry/WebSocketsParser.cs
+++ b/src/ReverseProxy/WebSocketsTelemetry/WebSocketsParser.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.Diagnostics;

--- a/src/ReverseProxy/WebSocketsTelemetry/WebSocketsTelemetry.cs
+++ b/src/ReverseProxy/WebSocketsTelemetry/WebSocketsTelemetry.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Diagnostics.CodeAnalysis;
 using System.Diagnostics.Tracing;

--- a/src/ReverseProxy/WebSocketsTelemetry/WebSocketsTelemetryExtensions.cs
+++ b/src/ReverseProxy/WebSocketsTelemetry/WebSocketsTelemetryExtensions.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using Microsoft.Extensions.DependencyInjection;

--- a/src/ReverseProxy/WebSocketsTelemetry/WebSocketsTelemetryMiddleware.cs
+++ b/src/ReverseProxy/WebSocketsTelemetry/WebSocketsTelemetryMiddleware.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.Threading.Tasks;

--- a/src/ReverseProxy/WebSocketsTelemetry/WebSocketsTelemetryStream.cs
+++ b/src/ReverseProxy/WebSocketsTelemetry/WebSocketsTelemetryStream.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.IO;

--- a/src/TelemetryConsumption/EventListenerService.cs
+++ b/src/TelemetryConsumption/EventListenerService.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.Collections.Generic;

--- a/src/TelemetryConsumption/Forwarder/ForwarderEventListenerService.cs
+++ b/src/TelemetryConsumption/Forwarder/ForwarderEventListenerService.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.Collections.Generic;

--- a/src/TelemetryConsumption/Forwarder/ForwarderMetrics.cs
+++ b/src/TelemetryConsumption/Forwarder/ForwarderMetrics.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 

--- a/src/TelemetryConsumption/Forwarder/ForwarderStage.cs
+++ b/src/TelemetryConsumption/Forwarder/ForwarderStage.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 namespace Yarp.Telemetry.Consumption;
 

--- a/src/TelemetryConsumption/Forwarder/IForwarderTelemetryConsumer.cs
+++ b/src/TelemetryConsumption/Forwarder/IForwarderTelemetryConsumer.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using Yarp.ReverseProxy.Forwarder;

--- a/src/TelemetryConsumption/Http/HttpEventListenerService.cs
+++ b/src/TelemetryConsumption/Http/HttpEventListenerService.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.Collections.Generic;

--- a/src/TelemetryConsumption/Http/HttpMetrics.cs
+++ b/src/TelemetryConsumption/Http/HttpMetrics.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 

--- a/src/TelemetryConsumption/Http/IHttpTelemetryConsumer.cs
+++ b/src/TelemetryConsumption/Http/IHttpTelemetryConsumer.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.Net.Http;

--- a/src/TelemetryConsumption/IMetricsConsumer.cs
+++ b/src/TelemetryConsumption/IMetricsConsumer.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 namespace Yarp.Telemetry.Consumption;
 

--- a/src/TelemetryConsumption/Kestrel/IKestrelTelemetryConsumer.cs
+++ b/src/TelemetryConsumption/Kestrel/IKestrelTelemetryConsumer.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 

--- a/src/TelemetryConsumption/Kestrel/KestrelEventListenerService.cs
+++ b/src/TelemetryConsumption/Kestrel/KestrelEventListenerService.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections.Generic;
 using System.Collections.ObjectModel;

--- a/src/TelemetryConsumption/Kestrel/KestrelMetrics.cs
+++ b/src/TelemetryConsumption/Kestrel/KestrelMetrics.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 

--- a/src/TelemetryConsumption/MetricsOptions.cs
+++ b/src/TelemetryConsumption/MetricsOptions.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 

--- a/src/TelemetryConsumption/NameResolution/INameResolutionTelemetryConsumer.cs
+++ b/src/TelemetryConsumption/NameResolution/INameResolutionTelemetryConsumer.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 

--- a/src/TelemetryConsumption/NameResolution/NameResolutionEventListenerService.cs
+++ b/src/TelemetryConsumption/NameResolution/NameResolutionEventListenerService.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.Collections.Generic;

--- a/src/TelemetryConsumption/NameResolution/NameResolutionMetrics.cs
+++ b/src/TelemetryConsumption/NameResolution/NameResolutionMetrics.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 

--- a/src/TelemetryConsumption/NetSecurity/INetSecurityTelemetryConsumer.cs
+++ b/src/TelemetryConsumption/NetSecurity/INetSecurityTelemetryConsumer.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.Security.Authentication;

--- a/src/TelemetryConsumption/NetSecurity/NetSecurityEventListenerService.cs
+++ b/src/TelemetryConsumption/NetSecurity/NetSecurityEventListenerService.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.Collections.Generic;

--- a/src/TelemetryConsumption/NetSecurity/NetSecurityMetrics.cs
+++ b/src/TelemetryConsumption/NetSecurity/NetSecurityMetrics.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 

--- a/src/TelemetryConsumption/Sockets/ISocketsTelemetryConsumer.cs
+++ b/src/TelemetryConsumption/Sockets/ISocketsTelemetryConsumer.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.Net.Sockets;

--- a/src/TelemetryConsumption/Sockets/SocketsEventListenerService.cs
+++ b/src/TelemetryConsumption/Sockets/SocketsEventListenerService.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections.Generic;
 using System.Collections.ObjectModel;

--- a/src/TelemetryConsumption/Sockets/SocketsMetrics.cs
+++ b/src/TelemetryConsumption/Sockets/SocketsMetrics.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 

--- a/src/TelemetryConsumption/TelemetryConsumptionExtensions.cs
+++ b/src/TelemetryConsumption/TelemetryConsumptionExtensions.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.Diagnostics.CodeAnalysis;

--- a/src/TelemetryConsumption/WebSockets/IWebSocketsTelemetryConsumer.cs
+++ b/src/TelemetryConsumption/WebSockets/IWebSocketsTelemetryConsumer.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 

--- a/src/TelemetryConsumption/WebSockets/WebSocketCloseReason.cs
+++ b/src/TelemetryConsumption/WebSockets/WebSocketCloseReason.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 namespace Yarp.Telemetry.Consumption;
 

--- a/src/TelemetryConsumption/WebSockets/WebSocketsEventListenerService.cs
+++ b/src/TelemetryConsumption/WebSockets/WebSocketsEventListenerService.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.Collections.Generic;

--- a/test/Kubernetes.Tests/Certificates/CertificateHelperTests.cs
+++ b/test/Kubernetes.Tests/Certificates/CertificateHelperTests.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System.IO;
 using System.Linq;

--- a/test/Kubernetes.Tests/Client/ResourceInformerTests.cs
+++ b/test/Kubernetes.Tests/Client/ResourceInformerTests.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using k8s;
 using k8s.Models;

--- a/test/Kubernetes.Tests/Client/SyncResourceInformer.cs
+++ b/test/Kubernetes.Tests/Client/SyncResourceInformer.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using k8s;
 using k8s.Models;

--- a/test/Kubernetes.Tests/Client/V1DeploymentResourceInformer.cs
+++ b/test/Kubernetes.Tests/Client/V1DeploymentResourceInformer.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using k8s;
 using k8s.Autorest;

--- a/test/Kubernetes.Tests/Client/V1PodResourceInformer.cs
+++ b/test/Kubernetes.Tests/Client/V1PodResourceInformer.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using k8s;
 using k8s.Autorest;

--- a/test/Kubernetes.Tests/Hosting/BackgroundHostedServiceTests.cs
+++ b/test/Kubernetes.Tests/Hosting/BackgroundHostedServiceTests.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Hosting.Server;

--- a/test/Kubernetes.Tests/Hosting/Fakes/FakeBackgroundHostedService.cs
+++ b/test/Kubernetes.Tests/Hosting/Fakes/FakeBackgroundHostedService.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;

--- a/test/Kubernetes.Tests/Hosting/Fakes/FakeServer.cs
+++ b/test/Kubernetes.Tests/Hosting/Fakes/FakeServer.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using Microsoft.AspNetCore.Hosting.Server;
 using Microsoft.AspNetCore.Http.Features;

--- a/test/Kubernetes.Tests/Hosting/Fakes/TestLatch.cs
+++ b/test/Kubernetes.Tests/Hosting/Fakes/TestLatch.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.Threading;

--- a/test/Kubernetes.Tests/Hosting/Fakes/TestLatches.cs
+++ b/test/Kubernetes.Tests/Hosting/Fakes/TestLatches.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 namespace Yarp.Kubernetes.Tests.Hosting.Fakes;
 

--- a/test/Kubernetes.Tests/IngressCacheTests.cs
+++ b/test/Kubernetes.Tests/IngressCacheTests.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.Linq;

--- a/test/Kubernetes.Tests/IngressControllerTests.cs
+++ b/test/Kubernetes.Tests/IngressControllerTests.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using k8s;
 using k8s.Models;

--- a/test/Kubernetes.Tests/IngressConversionTests.cs
+++ b/test/Kubernetes.Tests/IngressConversionTests.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.Collections.Generic;

--- a/test/Kubernetes.Tests/KubeResourceGenerator.cs
+++ b/test/Kubernetes.Tests/KubeResourceGenerator.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.Collections.Generic;

--- a/test/Kubernetes.Tests/Management/KubernetesCoreExtensionsTests.cs
+++ b/test/Kubernetes.Tests/Management/KubernetesCoreExtensionsTests.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using k8s;
 using Microsoft.Extensions.DependencyInjection;

--- a/test/Kubernetes.Tests/NamespacedNameTests.cs
+++ b/test/Kubernetes.Tests/NamespacedNameTests.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using k8s.Models;
 using System.Collections.Generic;

--- a/test/Kubernetes.Tests/Queues/WorkQueueTests.cs
+++ b/test/Kubernetes.Tests/Queues/WorkQueueTests.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.Threading;

--- a/test/Kubernetes.Tests/Rate/LimitTests.cs
+++ b/test/Kubernetes.Tests/Rate/LimitTests.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using Xunit;

--- a/test/Kubernetes.Tests/Rate/LimiterTests.cs
+++ b/test/Kubernetes.Tests/Rate/LimiterTests.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using Polly;
 using System;

--- a/test/Kubernetes.Tests/Rate/ReservationTests.cs
+++ b/test/Kubernetes.Tests/Rate/ReservationTests.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using Xunit;

--- a/test/Kubernetes.Tests/ReconcilerTests.cs
+++ b/test/Kubernetes.Tests/ReconcilerTests.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using Moq;
 using System;

--- a/test/Kubernetes.Tests/TestCluster/Controllers/ResourceApiController.cs
+++ b/test/Kubernetes.Tests/TestCluster/Controllers/ResourceApiController.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using k8s.Models;
 using Microsoft.AspNetCore.Mvc;

--- a/test/Kubernetes.Tests/TestCluster/Controllers/ResourceApiGroupController.cs
+++ b/test/Kubernetes.Tests/TestCluster/Controllers/ResourceApiGroupController.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using k8s.Models;
 using Microsoft.AspNetCore.Mvc;

--- a/test/Kubernetes.Tests/TestCluster/ITestCluster.cs
+++ b/test/Kubernetes.Tests/TestCluster/ITestCluster.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using Microsoft.AspNetCore.Http;
 using System.Threading.Tasks;

--- a/test/Kubernetes.Tests/TestCluster/ITestClusterHost.cs
+++ b/test/Kubernetes.Tests/TestCluster/ITestClusterHost.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using k8s;
 using k8s.KubeConfigModels;

--- a/test/Kubernetes.Tests/TestCluster/Models/ListParameters.cs
+++ b/test/Kubernetes.Tests/TestCluster/Models/ListParameters.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using Microsoft.AspNetCore.Mvc;
 

--- a/test/Kubernetes.Tests/TestCluster/Models/ListResult.cs
+++ b/test/Kubernetes.Tests/TestCluster/Models/ListResult.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections.Generic;
 

--- a/test/Kubernetes.Tests/TestCluster/Models/ResourceObject.cs
+++ b/test/Kubernetes.Tests/TestCluster/Models/ResourceObject.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using k8s;
 using k8s.Models;

--- a/test/Kubernetes.Tests/TestCluster/TestCluster.cs
+++ b/test/Kubernetes.Tests/TestCluster/TestCluster.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Options;

--- a/test/Kubernetes.Tests/TestCluster/TestClusterHost.cs
+++ b/test/Kubernetes.Tests/TestCluster/TestClusterHost.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using k8s;
 using k8s.KubeConfigModels;

--- a/test/Kubernetes.Tests/TestCluster/TestClusterHostBuilder.cs
+++ b/test/Kubernetes.Tests/TestCluster/TestClusterHostBuilder.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using k8s;
 using k8s.KubeConfigModels;

--- a/test/Kubernetes.Tests/TestCluster/TestClusterOptions.cs
+++ b/test/Kubernetes.Tests/TestCluster/TestClusterOptions.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using k8s;
 using k8s.Models;

--- a/test/Kubernetes.Tests/TestCluster/TestClusterStartup.cs
+++ b/test/Kubernetes.Tests/TestCluster/TestClusterStartup.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;

--- a/test/Kubernetes.Tests/Utils/ResourceSerializers.cs
+++ b/test/Kubernetes.Tests/Utils/ResourceSerializers.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.Text.Json;

--- a/test/Kubernetes.Tests/Utils/TestLogger.cs
+++ b/test/Kubernetes.Tests/Utils/TestLogger.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using Microsoft.Extensions.Logging;

--- a/test/ReverseProxy.FunctionalTests/Common/Helpers.cs
+++ b/test/ReverseProxy.FunctionalTests/Common/Helpers.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using Microsoft.AspNetCore.Hosting.Server;
 using Microsoft.AspNetCore.Hosting.Server.Features;

--- a/test/ReverseProxy.FunctionalTests/Common/TestEnvironment.cs
+++ b/test/ReverseProxy.FunctionalTests/Common/TestEnvironment.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.Collections.Generic;

--- a/test/ReverseProxy.FunctionalTests/Common/TestUrlHelper.cs
+++ b/test/ReverseProxy.FunctionalTests/Common/TestUrlHelper.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 

--- a/test/ReverseProxy.FunctionalTests/DistributedTracingTests.cs
+++ b/test/ReverseProxy.FunctionalTests/DistributedTracingTests.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Diagnostics;
 using System.Linq;

--- a/test/ReverseProxy.FunctionalTests/Expect100ContinueTests.cs
+++ b/test/ReverseProxy.FunctionalTests/Expect100ContinueTests.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.IO;

--- a/test/ReverseProxy.FunctionalTests/HeaderTests.cs
+++ b/test/ReverseProxy.FunctionalTests/HeaderTests.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.Collections.Generic;

--- a/test/ReverseProxy.FunctionalTests/HttpForwarderCancellationTests.cs
+++ b/test/ReverseProxy.FunctionalTests/HttpForwarderCancellationTests.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.IO;

--- a/test/ReverseProxy.FunctionalTests/HttpProxyCookieTests.cs
+++ b/test/ReverseProxy.FunctionalTests/HttpProxyCookieTests.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.Net;

--- a/test/ReverseProxy.FunctionalTests/HttpSysDelegationTests.cs
+++ b/test/ReverseProxy.FunctionalTests/HttpSysDelegationTests.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.Collections.Generic;

--- a/test/ReverseProxy.FunctionalTests/PassiveHealthCheckTests.cs
+++ b/test/ReverseProxy.FunctionalTests/PassiveHealthCheckTests.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.IO;

--- a/test/ReverseProxy.FunctionalTests/TelemetryConsumptionTests.cs
+++ b/test/ReverseProxy.FunctionalTests/TelemetryConsumptionTests.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.Collections.Concurrent;

--- a/test/ReverseProxy.FunctionalTests/TelemetryEnumTests.cs
+++ b/test/ReverseProxy.FunctionalTests/TelemetryEnumTests.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.Linq;

--- a/test/ReverseProxy.FunctionalTests/WebSocketTests.cs
+++ b/test/ReverseProxy.FunctionalTests/WebSocketTests.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.Diagnostics;

--- a/test/ReverseProxy.FunctionalTests/WebSocketsTelemetryTests.cs
+++ b/test/ReverseProxy.FunctionalTests/WebSocketsTelemetryTests.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 #nullable enable
 

--- a/test/ReverseProxy.Tests/Common/HttpContentExtensions.cs
+++ b/test/ReverseProxy.Tests/Common/HttpContentExtensions.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System.IO;
 using System.Net.Http;

--- a/test/ReverseProxy.Tests/Common/TestResources.cs
+++ b/test/ReverseProxy.Tests/Common/TestResources.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections.Generic;
 using System.IO;

--- a/test/ReverseProxy.Tests/Common/TestTrailersFeature.cs
+++ b/test/ReverseProxy.Tests/Common/TestTrailersFeature.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using Microsoft.AspNetCore.Http.Features;
 using Microsoft.AspNetCore.Http;

--- a/test/ReverseProxy.Tests/Configuration/ActiveHealthCheckConfigTests.cs
+++ b/test/ReverseProxy.Tests/Configuration/ActiveHealthCheckConfigTests.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using Xunit;

--- a/test/ReverseProxy.Tests/Configuration/ClusterConfigTests.cs
+++ b/test/ReverseProxy.Tests/Configuration/ClusterConfigTests.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.Collections.Generic;

--- a/test/ReverseProxy.Tests/Configuration/ConfigProvider/ConfigurationConfigProviderTests.cs
+++ b/test/ReverseProxy.Tests/Configuration/ConfigProvider/ConfigurationConfigProviderTests.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.Collections;

--- a/test/ReverseProxy.Tests/Configuration/ConfigProvider/ConfigurationReadingExtensionsTests.cs
+++ b/test/ReverseProxy.Tests/Configuration/ConfigProvider/ConfigurationReadingExtensionsTests.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections.Generic;
 using Xunit;

--- a/test/ReverseProxy.Tests/Configuration/ConfigValidatorTests.cs
+++ b/test/ReverseProxy.Tests/Configuration/ConfigValidatorTests.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.Collections.Generic;

--- a/test/ReverseProxy.Tests/Configuration/DestinationConfigTests.cs
+++ b/test/ReverseProxy.Tests/Configuration/DestinationConfigTests.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections.Generic;
 using Xunit;

--- a/test/ReverseProxy.Tests/Configuration/HealthCheckConfigTests.cs
+++ b/test/ReverseProxy.Tests/Configuration/HealthCheckConfigTests.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using Xunit;

--- a/test/ReverseProxy.Tests/Configuration/HttpClientConfigTests.cs
+++ b/test/ReverseProxy.Tests/Configuration/HttpClientConfigTests.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.Security.Authentication;

--- a/test/ReverseProxy.Tests/Configuration/PassiveHealthCheckConfigTests.cs
+++ b/test/ReverseProxy.Tests/Configuration/PassiveHealthCheckConfigTests.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using Xunit;

--- a/test/ReverseProxy.Tests/Configuration/RouteConfigTests.cs
+++ b/test/ReverseProxy.Tests/Configuration/RouteConfigTests.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.Collections.Generic;

--- a/test/ReverseProxy.Tests/Configuration/RouteHeaderTests.cs
+++ b/test/ReverseProxy.Tests/Configuration/RouteHeaderTests.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using Xunit;
 

--- a/test/ReverseProxy.Tests/Configuration/RouteMatchTests.cs
+++ b/test/ReverseProxy.Tests/Configuration/RouteMatchTests.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using Xunit;
 

--- a/test/ReverseProxy.Tests/Configuration/RouteQueryParameterTests.cs
+++ b/test/ReverseProxy.Tests/Configuration/RouteQueryParameterTests.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using Xunit;
 

--- a/test/ReverseProxy.Tests/Configuration/SessionAffinityConfigTests.cs
+++ b/test/ReverseProxy.Tests/Configuration/SessionAffinityConfigTests.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using Xunit;
 

--- a/test/ReverseProxy.Tests/Configuration/YarpOutputCachePolicyProviderTests.cs
+++ b/test/ReverseProxy.Tests/Configuration/YarpOutputCachePolicyProviderTests.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 #if NET7_0_OR_GREATER
 using System;

--- a/test/ReverseProxy.Tests/Configuration/YarpRateLimiterPolicyProviderTests.cs
+++ b/test/ReverseProxy.Tests/Configuration/YarpRateLimiterPolicyProviderTests.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 #if NET7_0_OR_GREATER
 using System;

--- a/test/ReverseProxy.Tests/Delegation/HttpSysDelegatorMiddlewareTests.cs
+++ b/test/ReverseProxy.Tests/Delegation/HttpSysDelegatorMiddlewareTests.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.Collections.Generic;

--- a/test/ReverseProxy.Tests/Delegation/HttpSysDelegatorTests.cs
+++ b/test/ReverseProxy.Tests/Delegation/HttpSysDelegatorTests.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.Collections.Generic;

--- a/test/ReverseProxy.Tests/Forwarder/ForwarderHttpClientFactoryTests.cs
+++ b/test/ReverseProxy.Tests/Forwarder/ForwarderHttpClientFactoryTests.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.Collections.Generic;

--- a/test/ReverseProxy.Tests/Forwarder/ForwarderMiddlewareTests.cs
+++ b/test/ReverseProxy.Tests/Forwarder/ForwarderMiddlewareTests.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.Collections.Generic;

--- a/test/ReverseProxy.Tests/Forwarder/HttpForwarderTests.cs
+++ b/test/ReverseProxy.Tests/Forwarder/HttpForwarderTests.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.Collections.Generic;

--- a/test/ReverseProxy.Tests/Forwarder/HttpTransformerTests.cs
+++ b/test/ReverseProxy.Tests/Forwarder/HttpTransformerTests.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.Collections.Generic;

--- a/test/ReverseProxy.Tests/Forwarder/RequestUtilitiesTests.cs
+++ b/test/ReverseProxy.Tests/Forwarder/RequestUtilitiesTests.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.Net.Http;

--- a/test/ReverseProxy.Tests/Forwarder/ReverseProxyServiceCollectionTests.cs
+++ b/test/ReverseProxy.Tests/Forwarder/ReverseProxyServiceCollectionTests.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.Net.Http;

--- a/test/ReverseProxy.Tests/Forwarder/StreamCopierTests.cs
+++ b/test/ReverseProxy.Tests/Forwarder/StreamCopierTests.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.Collections.Generic;

--- a/test/ReverseProxy.Tests/Forwarder/StreamCopyHttpContentTests.cs
+++ b/test/ReverseProxy.Tests/Forwarder/StreamCopyHttpContentTests.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.IO;

--- a/test/ReverseProxy.Tests/Health/ActiveHealthCheckMonitorTests.cs
+++ b/test/ReverseProxy.Tests/Health/ActiveHealthCheckMonitorTests.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.Collections.Generic;

--- a/test/ReverseProxy.Tests/Health/ClusterDestinationsUpdaterTests.cs
+++ b/test/ReverseProxy.Tests/Health/ClusterDestinationsUpdaterTests.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections.Generic;
 using System.Linq;

--- a/test/ReverseProxy.Tests/Health/ConsecutiveFailuresHealthPolicyTests.cs
+++ b/test/ReverseProxy.Tests/Health/ConsecutiveFailuresHealthPolicyTests.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.Collections.Generic;

--- a/test/ReverseProxy.Tests/Health/DefaultProbingRequestFactoryTests.cs
+++ b/test/ReverseProxy.Tests/Health/DefaultProbingRequestFactoryTests.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.Net;

--- a/test/ReverseProxy.Tests/Health/DestinationHealthUpdaterTests.cs
+++ b/test/ReverseProxy.Tests/Health/DestinationHealthUpdaterTests.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.Linq;

--- a/test/ReverseProxy.Tests/Health/EntityActionSchedulerTests.cs
+++ b/test/ReverseProxy.Tests/Health/EntityActionSchedulerTests.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.Threading;

--- a/test/ReverseProxy.Tests/Health/HealthyAndUnknownDestinationsPolicyTests.cs
+++ b/test/ReverseProxy.Tests/Health/HealthyAndUnknownDestinationsPolicyTests.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections.Generic;
 using Xunit;

--- a/test/ReverseProxy.Tests/Health/HealthyOrPanicDestinationsPolicyTests.cs
+++ b/test/ReverseProxy.Tests/Health/HealthyOrPanicDestinationsPolicyTests.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using Xunit;
 using Yarp.ReverseProxy.Configuration;

--- a/test/ReverseProxy.Tests/Health/PassiveHealthCheckMiddlewareTests.cs
+++ b/test/ReverseProxy.Tests/Health/PassiveHealthCheckMiddlewareTests.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Linq;
 using System.Net.Http;

--- a/test/ReverseProxy.Tests/Health/TransportFailureRateHealthPolicyTests.cs
+++ b/test/ReverseProxy.Tests/Health/TransportFailureRateHealthPolicyTests.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.Collections.Generic;

--- a/test/ReverseProxy.Tests/Limits/LimitsMiddlewareTests.cs
+++ b/test/ReverseProxy.Tests/Limits/LimitsMiddlewareTests.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Net.Http;
 using System.Threading.Tasks;

--- a/test/ReverseProxy.Tests/LoadBalancing/LoadBalancerMiddlewareTests.cs
+++ b/test/ReverseProxy.Tests/LoadBalancing/LoadBalancerMiddlewareTests.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.Collections.Generic;

--- a/test/ReverseProxy.Tests/LoadBalancing/LoadBalancingPoliciesTests.cs
+++ b/test/ReverseProxy.Tests/LoadBalancing/LoadBalancingPoliciesTests.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.Linq;

--- a/test/ReverseProxy.Tests/Management/ProxyConfigManagerTests.cs
+++ b/test/ReverseProxy.Tests/Management/ProxyConfigManagerTests.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.Collections.Generic;

--- a/test/ReverseProxy.Tests/Model/DestinationStateTests.cs
+++ b/test/ReverseProxy.Tests/Model/DestinationStateTests.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.Collections.Generic;

--- a/test/ReverseProxy.Tests/Model/HttpContextFeaturesExtensions.cs
+++ b/test/ReverseProxy.Tests/Model/HttpContextFeaturesExtensions.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Net.Http;
 using Microsoft.AspNetCore.Http;

--- a/test/ReverseProxy.Tests/Model/ProxyPipelineInitializerMiddlewareTests.cs
+++ b/test/ReverseProxy.Tests/Model/ProxyPipelineInitializerMiddlewareTests.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.Collections.Generic;

--- a/test/ReverseProxy.Tests/Routing/HeaderMatcherPolicyTests.cs
+++ b/test/ReverseProxy.Tests/Routing/HeaderMatcherPolicyTests.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.Collections.Generic;

--- a/test/ReverseProxy.Tests/Routing/QueryMatcherPolicyTests.cs
+++ b/test/ReverseProxy.Tests/Routing/QueryMatcherPolicyTests.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.Collections.Generic;

--- a/test/ReverseProxy.Tests/Routing/RoutingTests.cs
+++ b/test/ReverseProxy.Tests/Routing/RoutingTests.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.Collections.Generic;

--- a/test/ReverseProxy.Tests/SessionAffinity/AffinitizeTransformProviderTests.cs
+++ b/test/ReverseProxy.Tests/SessionAffinity/AffinitizeTransformProviderTests.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.Linq;

--- a/test/ReverseProxy.Tests/SessionAffinity/AffinitizeTransformTests.cs
+++ b/test/ReverseProxy.Tests/SessionAffinity/AffinitizeTransformTests.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Linq;
 using System.Net.Http;

--- a/test/ReverseProxy.Tests/SessionAffinity/AffinityTestHelper.cs
+++ b/test/ReverseProxy.Tests/SessionAffinity/AffinityTestHelper.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.Text;

--- a/test/ReverseProxy.Tests/SessionAffinity/ArrCookieSessionAffinityPolicyTests.cs
+++ b/test/ReverseProxy.Tests/SessionAffinity/ArrCookieSessionAffinityPolicyTests.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.Collections.Generic;

--- a/test/ReverseProxy.Tests/SessionAffinity/BaseSessionAffinityPolicyTests.cs
+++ b/test/ReverseProxy.Tests/SessionAffinity/BaseSessionAffinityPolicyTests.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.Collections.Generic;

--- a/test/ReverseProxy.Tests/SessionAffinity/CookieSessionAffinityPolicyTests.cs
+++ b/test/ReverseProxy.Tests/SessionAffinity/CookieSessionAffinityPolicyTests.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.Collections.Generic;

--- a/test/ReverseProxy.Tests/SessionAffinity/CustomHeaderSessionAffinityPolicyTests.cs
+++ b/test/ReverseProxy.Tests/SessionAffinity/CustomHeaderSessionAffinityPolicyTests.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections.Generic;
 using Microsoft.AspNetCore.Http;

--- a/test/ReverseProxy.Tests/SessionAffinity/HashCookieSessionAffinityPolicyTests.cs
+++ b/test/ReverseProxy.Tests/SessionAffinity/HashCookieSessionAffinityPolicyTests.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.Collections.Generic;

--- a/test/ReverseProxy.Tests/SessionAffinity/RedistributeAffinityFailurePolicyTests.cs
+++ b/test/ReverseProxy.Tests/SessionAffinity/RedistributeAffinityFailurePolicyTests.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.Threading.Tasks;

--- a/test/ReverseProxy.Tests/SessionAffinity/Return503ErrorAffinityFailurePolicyTests.cs
+++ b/test/ReverseProxy.Tests/SessionAffinity/Return503ErrorAffinityFailurePolicyTests.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.Threading.Tasks;

--- a/test/ReverseProxy.Tests/SessionAffinity/SessionAffinityMiddlewareTests.cs
+++ b/test/ReverseProxy.Tests/SessionAffinity/SessionAffinityMiddlewareTests.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.Collections.Generic;

--- a/test/ReverseProxy.Tests/Transforms/Builder/TransformBuilderTests.cs
+++ b/test/ReverseProxy.Tests/Transforms/Builder/TransformBuilderTests.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.Collections.Generic;

--- a/test/ReverseProxy.Tests/Transforms/DestinationPrefixTransformTests.cs
+++ b/test/ReverseProxy.Tests/Transforms/DestinationPrefixTransformTests.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Threading.Tasks;
 using Xunit;

--- a/test/ReverseProxy.Tests/Transforms/ForwardedTransformExtensionsTests.cs
+++ b/test/ReverseProxy.Tests/Transforms/ForwardedTransformExtensionsTests.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.Collections.Generic;

--- a/test/ReverseProxy.Tests/Transforms/HttpMethodChangeTransformTests.cs
+++ b/test/ReverseProxy.Tests/Transforms/HttpMethodChangeTransformTests.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Net.Http;
 using System.Threading.Tasks;

--- a/test/ReverseProxy.Tests/Transforms/HttpMethodTransformExtensionsTests.cs
+++ b/test/ReverseProxy.Tests/Transforms/HttpMethodTransformExtensionsTests.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Net.Http;
 using Microsoft.AspNetCore.Http;

--- a/test/ReverseProxy.Tests/Transforms/PathRouteValuesTransformTests.cs
+++ b/test/ReverseProxy.Tests/Transforms/PathRouteValuesTransformTests.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections.Generic;
 using System.Threading.Tasks;

--- a/test/ReverseProxy.Tests/Transforms/PathStringTransformTests.cs
+++ b/test/ReverseProxy.Tests/Transforms/PathStringTransformTests.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.Threading.Tasks;

--- a/test/ReverseProxy.Tests/Transforms/PathTransformExtensionsTests.cs
+++ b/test/ReverseProxy.Tests/Transforms/PathTransformExtensionsTests.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Routing.Template;

--- a/test/ReverseProxy.Tests/Transforms/QueryParameterFromRouteTransformTests.cs
+++ b/test/ReverseProxy.Tests/Transforms/QueryParameterFromRouteTransformTests.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;

--- a/test/ReverseProxy.Tests/Transforms/QueryParameterFromStaticTransformTests.cs
+++ b/test/ReverseProxy.Tests/Transforms/QueryParameterFromStaticTransformTests.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;

--- a/test/ReverseProxy.Tests/Transforms/QueryParameterRemoveTransformTests.cs
+++ b/test/ReverseProxy.Tests/Transforms/QueryParameterRemoveTransformTests.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;

--- a/test/ReverseProxy.Tests/Transforms/QueryTransformContextTests.cs
+++ b/test/ReverseProxy.Tests/Transforms/QueryTransformContextTests.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using Microsoft.AspNetCore.Http;
 using Xunit;

--- a/test/ReverseProxy.Tests/Transforms/QueryTransformExtensionsTests.cs
+++ b/test/ReverseProxy.Tests/Transforms/QueryTransformExtensionsTests.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using Xunit;
 using Yarp.ReverseProxy.Configuration;

--- a/test/ReverseProxy.Tests/Transforms/RequestHeaderClientCertTransformTests.cs
+++ b/test/ReverseProxy.Tests/Transforms/RequestHeaderClientCertTransformTests.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.IO;

--- a/test/ReverseProxy.Tests/Transforms/RequestHeaderForwardedTransformTests.cs
+++ b/test/ReverseProxy.Tests/Transforms/RequestHeaderForwardedTransformTests.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.Net;

--- a/test/ReverseProxy.Tests/Transforms/RequestHeaderRemoveTransformTests.cs
+++ b/test/ReverseProxy.Tests/Transforms/RequestHeaderRemoveTransformTests.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.Linq;

--- a/test/ReverseProxy.Tests/Transforms/RequestHeaderValueTransformTests.cs
+++ b/test/ReverseProxy.Tests/Transforms/RequestHeaderValueTransformTests.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.Net.Http;

--- a/test/ReverseProxy.Tests/Transforms/RequestHeaderXForwardedForTransformTests.cs
+++ b/test/ReverseProxy.Tests/Transforms/RequestHeaderXForwardedForTransformTests.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.Net;

--- a/test/ReverseProxy.Tests/Transforms/RequestHeaderXForwardedHostTransformTests.cs
+++ b/test/ReverseProxy.Tests/Transforms/RequestHeaderXForwardedHostTransformTests.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.Net.Http;

--- a/test/ReverseProxy.Tests/Transforms/RequestHeaderXForwardedPrefixTransformTests.cs
+++ b/test/ReverseProxy.Tests/Transforms/RequestHeaderXForwardedPrefixTransformTests.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.Net.Http;

--- a/test/ReverseProxy.Tests/Transforms/RequestHeaderXForwardedProtoTransformTests.cs
+++ b/test/ReverseProxy.Tests/Transforms/RequestHeaderXForwardedProtoTransformTests.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.Net.Http;

--- a/test/ReverseProxy.Tests/Transforms/RequestHeadersAllowedTransformTests.cs
+++ b/test/ReverseProxy.Tests/Transforms/RequestHeadersAllowedTransformTests.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.Linq;

--- a/test/ReverseProxy.Tests/Transforms/RequestHeadersTransformExtensionsTests.cs
+++ b/test/ReverseProxy.Tests/Transforms/RequestHeadersTransformExtensionsTests.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Linq;
 using Xunit;

--- a/test/ReverseProxy.Tests/Transforms/RequestTransformTests.cs
+++ b/test/ReverseProxy.Tests/Transforms/RequestTransformTests.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Linq;
 using System.Net.Http;

--- a/test/ReverseProxy.Tests/Transforms/ResponseHeaderRemoveTransformTests.cs
+++ b/test/ReverseProxy.Tests/Transforms/ResponseHeaderRemoveTransformTests.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.Linq;

--- a/test/ReverseProxy.Tests/Transforms/ResponseHeaderValueTransformTests.cs
+++ b/test/ReverseProxy.Tests/Transforms/ResponseHeaderValueTransformTests.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Net.Http;
 using System.Threading.Tasks;

--- a/test/ReverseProxy.Tests/Transforms/ResponseHeadersAllowedTransformTests.cs
+++ b/test/ReverseProxy.Tests/Transforms/ResponseHeadersAllowedTransformTests.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.Linq;

--- a/test/ReverseProxy.Tests/Transforms/ResponseTrailerRemoveTransformTests.cs
+++ b/test/ReverseProxy.Tests/Transforms/ResponseTrailerRemoveTransformTests.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.Linq;

--- a/test/ReverseProxy.Tests/Transforms/ResponseTrailerValueTransformTests.cs
+++ b/test/ReverseProxy.Tests/Transforms/ResponseTrailerValueTransformTests.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Net.Http;
 using System.Threading.Tasks;

--- a/test/ReverseProxy.Tests/Transforms/ResponseTrailersAllowedTransformTests.cs
+++ b/test/ReverseProxy.Tests/Transforms/ResponseTrailersAllowedTransformTests.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.Linq;

--- a/test/ReverseProxy.Tests/Transforms/ResponseTrailersTransformTests.cs
+++ b/test/ReverseProxy.Tests/Transforms/ResponseTrailersTransformTests.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Net.Http;
 using Microsoft.AspNetCore.Http;

--- a/test/ReverseProxy.Tests/Transforms/ResponseTransformExtensionsTests.cs
+++ b/test/ReverseProxy.Tests/Transforms/ResponseTransformExtensionsTests.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using Xunit;
 using Yarp.ReverseProxy.Configuration;

--- a/test/ReverseProxy.Tests/Transforms/ResponseTransformTests.cs
+++ b/test/ReverseProxy.Tests/Transforms/ResponseTransformTests.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Net.Http;
 using Microsoft.AspNetCore.Http;

--- a/test/ReverseProxy.Tests/Transforms/TransformBuilderContextFuncExtensionsTests.cs
+++ b/test/ReverseProxy.Tests/Transforms/TransformBuilderContextFuncExtensionsTests.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using Xunit;
 

--- a/test/ReverseProxy.Tests/Transforms/TransformExtentionsTestsBase.cs
+++ b/test/ReverseProxy.Tests/Transforms/TransformExtentionsTestsBase.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using Xunit;

--- a/test/ReverseProxy.Tests/Utilities/ActivityCancellationTokenSourceTests.cs
+++ b/test/ReverseProxy.Tests/Utilities/ActivityCancellationTokenSourceTests.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.Collections.Generic;

--- a/test/ReverseProxy.Tests/Utilities/AtomicCounterTests.cs
+++ b/test/ReverseProxy.Tests/Utilities/AtomicCounterTests.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Threading.Tasks;
 using Xunit;

--- a/test/ReverseProxy.Tests/Utilities/CaseInsensitiveEqualHelperTests.cs
+++ b/test/ReverseProxy.Tests/Utilities/CaseInsensitiveEqualHelperTests.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using Xunit;
 

--- a/test/ReverseProxy.Tests/Utilities/RandomFactoryTests.cs
+++ b/test/ReverseProxy.Tests/Utilities/RandomFactoryTests.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using Xunit;
 

--- a/test/ReverseProxy.Tests/WebSocketsTelemetry/WebSocketsParserTests.cs
+++ b/test/ReverseProxy.Tests/WebSocketsTelemetry/WebSocketsParserTests.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.IO;

--- a/test/Tests.Common/TestAutoMockBase.cs
+++ b/test/Tests.Common/TestAutoMockBase.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using Autofac.Core;

--- a/test/Tests.Common/TestRandom.cs
+++ b/test/Tests.Common/TestRandom.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 

--- a/test/Tests.Common/TestRandomFactory.cs
+++ b/test/Tests.Common/TestRandomFactory.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using Yarp.ReverseProxy.Utilities;

--- a/test/Tests.Common/TestTimeProvider.cs
+++ b/test/Tests.Common/TestTimeProvider.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.Collections.Generic;

--- a/testassets/BenchmarkApp/Program.cs
+++ b/testassets/BenchmarkApp/Program.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.Diagnostics;

--- a/testassets/ReverseProxy.Code/Controllers/HealthController.cs
+++ b/testassets/ReverseProxy.Code/Controllers/HealthController.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using Microsoft.AspNetCore.Mvc;
 using Yarp.ReverseProxy.Health;

--- a/testassets/ReverseProxy.Code/ForwarderMetricsConsumer.cs
+++ b/testassets/ReverseProxy.Code/ForwarderMetricsConsumer.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using Yarp.Telemetry.Consumption;

--- a/testassets/ReverseProxy.Code/ForwarderTelemetryConsumer.cs
+++ b/testassets/ReverseProxy.Code/ForwarderTelemetryConsumer.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.Threading;

--- a/testassets/ReverseProxy.Code/MyTransformFactory.cs
+++ b/testassets/ReverseProxy.Code/MyTransformFactory.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.Collections.Generic;

--- a/testassets/ReverseProxy.Code/MyTransformProvider.cs
+++ b/testassets/ReverseProxy.Code/MyTransformProvider.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.Net.Http;

--- a/testassets/ReverseProxy.Code/Program.cs
+++ b/testassets/ReverseProxy.Code/Program.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.Collections.Generic;

--- a/testassets/ReverseProxy.Code/TokenService.cs
+++ b/testassets/ReverseProxy.Code/TokenService.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Security.Claims;
 using System.Threading.Tasks;

--- a/testassets/ReverseProxy.Config/Controllers/HealthController.cs
+++ b/testassets/ReverseProxy.Config/Controllers/HealthController.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using Microsoft.AspNetCore.Mvc;
 

--- a/testassets/ReverseProxy.Config/CustomConfigFilter.cs
+++ b/testassets/ReverseProxy.Config/CustomConfigFilter.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.Threading;

--- a/testassets/ReverseProxy.Config/Program.cs
+++ b/testassets/ReverseProxy.Config/Program.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using Microsoft.AspNetCore.Builder;
 using Microsoft.Extensions.DependencyInjection;

--- a/testassets/ReverseProxy.Direct/Program.cs
+++ b/testassets/ReverseProxy.Direct/Program.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;

--- a/testassets/ReverseProxy.Direct/TlsFilter.cs
+++ b/testassets/ReverseProxy.Direct/TlsFilter.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.Buffers;

--- a/testassets/TestClient/CommandLineArgs.cs
+++ b/testassets/TestClient/CommandLineArgs.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 

--- a/testassets/TestClient/Program.cs
+++ b/testassets/TestClient/Program.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.Collections.Generic;

--- a/testassets/TestClient/Scenarios/Http1Scenario.cs
+++ b/testassets/TestClient/Scenarios/Http1Scenario.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.Diagnostics;

--- a/testassets/TestClient/Scenarios/Http2PostExpectContinueScenario.cs
+++ b/testassets/TestClient/Scenarios/Http2PostExpectContinueScenario.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.Diagnostics;

--- a/testassets/TestClient/Scenarios/Http2Scenario.cs
+++ b/testassets/TestClient/Scenarios/Http2Scenario.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.Diagnostics;

--- a/testassets/TestClient/Scenarios/IScenario.cs
+++ b/testassets/TestClient/Scenarios/IScenario.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Threading;
 using System.Threading.Tasks;

--- a/testassets/TestClient/Scenarios/RawUpgradeScenario.cs
+++ b/testassets/TestClient/Scenarios/RawUpgradeScenario.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.Diagnostics;

--- a/testassets/TestClient/Scenarios/SessionAffinityScenario.cs
+++ b/testassets/TestClient/Scenarios/SessionAffinityScenario.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.Diagnostics;

--- a/testassets/TestClient/Scenarios/WebSocketsScenario.cs
+++ b/testassets/TestClient/Scenarios/WebSocketsScenario.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.Diagnostics;

--- a/testassets/TestServer/AssemblyInfo.cs
+++ b/testassets/TestServer/AssemblyInfo.cs
@@ -1,2 +1,2 @@
-﻿// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.

--- a/testassets/TestServer/Controllers/HealthController.cs
+++ b/testassets/TestServer/Controllers/HealthController.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using Microsoft.AspNetCore.Mvc;
 

--- a/testassets/TestServer/Controllers/HttpController.cs
+++ b/testassets/TestServer/Controllers/HttpController.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.Collections.Generic;

--- a/testassets/TestServer/Controllers/UpgradeController.cs
+++ b/testassets/TestServer/Controllers/UpgradeController.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System.IO;
 using System.Threading.Tasks;

--- a/testassets/TestServer/Controllers/WebSocketsController.cs
+++ b/testassets/TestServer/Controllers/WebSocketsController.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.Net.WebSockets;

--- a/testassets/TestServer/Program.cs
+++ b/testassets/TestServer/Program.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using Microsoft.AspNetCore.Builder;
 using Microsoft.Extensions.DependencyInjection;


### PR DESCRIPTION
Replace the Microsoft file headers and LICENSE file with the .NET Foundation one. The license content itself doesn't change.

@richlander @ChrisSfanos 