### PR TITLE
Remove semi-duplicated code-block

### DIFF
--- a/docs/docfx/articles/direct-forwarding.md
+++ b/docs/docfx/articles/direct-forwarding.md
@@ -127,29 +127,6 @@ internal class CustomTransformer : HttpTransformer
 }
 ```
 
-```C#
-private class CustomTransformer : HttpTransformer
-{
-    public override async ValueTask TransformRequestAsync(HttpContext httpContext,
-        HttpRequestMessage proxyRequest, string destinationPrefix, CancellationToken cancellationToken)
-    {
-        // Copy all request headers
-        await base.TransformRequestAsync(httpContext, proxyRequest, destinationPrefix, cancellationToken);
-
-        // Customize the query string:
-        var queryContext = new QueryTransformContext(httpContext.Request);
-        queryContext.Collection.Remove("param1");
-        queryContext.Collection["area"] = "xx2";
-
-        // Assign the custom uri. Be careful about extra slashes when concatenating here. RequestUtilities.MakeDestinationAddress is a safe default.
-        proxyRequest.RequestUri = RequestUtilities.MakeDestinationAddress("https://example.com", httpContext.Request.Path, queryContext.QueryString);
-
-        // Suppress the original request header, use the one from the destination Uri.
-        proxyRequest.Headers.Host = null;
-    }
-}
-```
-
 There are also [extension methods](xref:Microsoft.AspNetCore.Builder.DirectForwardingIEndpointRouteBuilderExtensions) available that simplify the mapping of IHttpForwarder to endpoints.
 
 ```C#


### PR DESCRIPTION
The CustomTransformer class is included twice in the example, once as an internal and once as a private class.  The corresponding sample project only has the internal, and I therefor propose to remove the private class definition