### PR TITLE
Add a Json schema for YARP configuration

### DIFF
--- a/YARP.sln
+++ b/YARP.sln
@@ -9,6 +9,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		global.json = global.json
 		NuGet.config = NuGet.config
 		TFMs.props = TFMs.props
+		eng\Versions.props = eng\Versions.props
 	EndProjectSection
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Yarp.ReverseProxy", "src\ReverseProxy\Yarp.ReverseProxy.csproj", "{568EF8AE-7624-490D-A19F-C25D076FF091}"

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -33,6 +33,7 @@
     <SerilogSinksConsoleVersion>3.1.1</SerilogSinksConsoleVersion>
     <YamlDotNetVersion>16.2.1</YamlDotNetVersion>
     <KubernetesClientVersion>15.0.1</KubernetesClientVersion>
+    <JsonSchemaNetVersion>7.0.2</JsonSchemaNetVersion>
     <!-- Container app dependencies -->
     <YarpNugetVersion>2.2.0</YarpNugetVersion>
     <MicrosoftExtensionsServiceDiscovery>8.2.2</MicrosoftExtensionsServiceDiscovery>

--- a/samples/ReverseProxy.Config.Sample/appsettings.json
+++ b/samples/ReverseProxy.Config.Sample/appsettings.json
@@ -80,7 +80,11 @@
           },
           "another_destination": {
             "Address": "https://10.20.30.40",
-            "Health": "https://10.20.30.40:12345" // override for active health checks
+            "Health": "https://10.20.30.40:12345", // override for active health checks
+            "Host": "contoso",
+            "Metadata": {
+              "SomeKey": "SomeValue"
+            }
           }
         },
         "LoadBalancingPolicy": "PowerOfTwoChoices", // Alternatively "First", "Random", "RoundRobin", "LeastRequests"
@@ -88,7 +92,17 @@
           "Enabled": true, // Defaults to 'false'
           "Policy": "HashCookie", // Default, alternatively "Cookie" or "CustomHeader"
           "FailurePolicy": "Redistribute", // default, alternatively "Return503Error"
-          "AffinityKeyName": "MySessionCookieName" // Required, no default
+          "AffinityKeyName": "MySessionCookieName", // Required, no default
+          "Cookie": { // Options for cookie based session affinity
+            "Path": "/",
+            "SameSite": "None",
+            "HttpOnly": true,
+            "Expiration": "00:30:00",
+            "Domain": "example.com",
+            "MaxAge": "08:00:00",
+            "SecurePolicy": "Always",
+            "IsEssential": true
+          }
         },
         "HealthCheck": { // Ways to determine which destinations should be filtered out due to unhealthy state
           "Active": { // Makes API calls to validate the health of each destination
@@ -96,14 +110,16 @@
             "Interval": "00:00:10", // How often to query for health data
             "Timeout": "00:00:10", // Timeout for the health check request/response
             "Policy": "ConsecutiveFailures", // Or other custom policy that has been registered
-            "Path": "/favicon.ico" // API endpoint to query for health state. Looks for 2XX response codes to indicate healthy state
+            "Path": "/favicon.ico", // API endpoint to query for health state. Looks for 2XX response codes to indicate healthy state
             // Typically something like "/api/health" but used favicon to enable sample to run
+            "Query": "?healthCheck=true" // Query string to append to the health check request
           },
           "Passive": { // Disables destinations based on HTTP response codes for proxy requests
             "Enabled": true, // Defaults to false
             "Policy": "TransportFailureRate", // Or other custom policy that has been registered
             "ReactivationPeriod": "00:00:10" // how long before the destination is re-enabled
-          }
+          },
+          "AvailableDestinationsPolicy": "HealthyOrPanic" // Policy for which destinations can be used when sending requests
         },
         "HttpClient": { // Configuration of HttpClient instance used to contact destinations
           "SslProtocols": [ "Tls13" ],
@@ -111,12 +127,18 @@
           "MaxConnectionsPerServer": 1024, // Destination server can further limit this number
           "EnableMultipleHttp2Connections": true,
           "RequestHeaderEncoding": "Latin1", // How to interpret non ASCII characters in proxied request's header values
-          "ResponseHeaderEncoding": "Latin1" // How to interpret non ASCII characters in proxied request's response header values
+          "ResponseHeaderEncoding": "Latin1", // How to interpret non ASCII characters in proxied request's response header values
+          "WebProxy": { // Optinal proxy configuration for outgoing requests
+            "Address": "127.0.0.1",
+            "BypassOnLocal": true,
+            "UseDefaultCredentials": false
+          }
         },
         "HttpRequest": { // Options for sending request to destination
           "ActivityTimeout": "00:02:00", // Activity timeout for the request
           "Version": "2", // Http Version that should be tried first
-          "VersionPolicy": "RequestVersionOrLower" // Policy for which other versions can be be used
+          "VersionPolicy": "RequestVersionOrLower", // Policy for which other versions can be be used
+          "AllowResponseBuffering": false
         },
         "Metadata": { // Custom Key/value pairs for extensibility
           "TransportFailureRateHealthPolicy.RateLimit": "0.5", // Used by Passive health policy

--- a/samples/ReverseProxy.Config.Sample/appsettings.json
+++ b/samples/ReverseProxy.Config.Sample/appsettings.json
@@ -92,7 +92,7 @@
         },
         "HealthCheck": { // Ways to determine which destinations should be filtered out due to unhealthy state
           "Active": { // Makes API calls to validate the health of each destination
-            "Enabled": "true",
+            "Enabled": true,
             "Interval": "00:00:10", // How often to query for health data
             "Timeout": "00:00:10", // Timeout for the health check request/response
             "Policy": "ConsecutiveFailures", // Or other custom policy that has been registered

--- a/samples/ReverseProxy.Config.Sample/appsettings.json
+++ b/samples/ReverseProxy.Config.Sample/appsettings.json
@@ -30,7 +30,7 @@
         // matches /download/* and routes to "allClusterProps"
         "ClusterId": "allClusterProps", // Name of one of the clusters
         "Order": 0, // Lower numbers have higher precidence, default is 0
-        "Authorization Policy": "Anonymous", // Name of the policy or "Default", "Anonymous"
+        "AuthorizationPolicy": "Anonymous", // Name of the policy or "Default", "Anonymous"
         "CorsPolicy": "disable", // Name of the CorsPolicy to apply to this route or "default", "disable"
         "Match": { // Rules that have to be met for the route to match the request
           "Path": "/download/{**remainder}", // The path to match using ASP.NET syntax.
@@ -53,7 +53,7 @@
             }
           ]
         },
-        "MetaData": { // List of key value pairs that can be used by custom extensions
+        "Metadata": { // List of key value pairs that can be used by custom extensions
           "MyName": "MyValue"
         },
         "Transforms": [ // List of transforms. See ReverseProxy.Transforms.Sample for more details
@@ -106,7 +106,7 @@
           }
         },
         "HttpClient": { // Configuration of HttpClient instance used to contact destinations
-          "SSLProtocols": "Tls13",
+          "SslProtocols": [ "Tls13" ],
           "DangerousAcceptAnyServerCertificate": true, // Disables destination cert validation
           "MaxConnectionsPerServer": 1024, // Destination server can further limit this number
           "EnableMultipleHttp2Connections": true,
@@ -114,11 +114,11 @@
           "ResponseHeaderEncoding": "Latin1" // How to interpret non ASCII characters in proxied request's response header values
         },
         "HttpRequest": { // Options for sending request to destination
-          "Timeout": "00:02:00", // Timeout for the HttpRequest
+          "ActivityTimeout": "00:02:00", // Activity timeout for the request
           "Version": "2", // Http Version that should be tried first
           "VersionPolicy": "RequestVersionOrLower" // Policy for which other versions can be be used
         },
-        "MetaData": { // Custom Key/value pairs for extensibility
+        "Metadata": { // Custom Key/value pairs for extensibility
           "TransportFailureRateHealthPolicy.RateLimit": "0.5", // Used by Passive health policy
           "MyKey": "MyValue"
         }

--- a/samples/ReverseProxy.Transforms.Sample/appsettings.json
+++ b/samples/ReverseProxy.Transforms.Sample/appsettings.json
@@ -26,8 +26,8 @@
         },
         "Transforms": [
           { "PathPrefix": "/prefix" },
-          { "RequestHeadersCopy": "true" },
-          { "RequestHeaderOriginalHost": "false" },
+          { "RequestHeadersCopy": true },
+          { "RequestHeaderOriginalHost": false },
           {
             "RequestHeader": "foo0",
             "Append": "bar"

--- a/src/Common/Package.targets
+++ b/src/Common/Package.targets
@@ -1,0 +1,6 @@
+<Project>
+  <ItemGroup>
+    <JsonSchemaSegment Include="$(MSBuildThisFileDirectory)..\..\ConfigurationSchema.json"
+                       FilePathPattern="appsettings\..*json" />
+  </ItemGroup>
+</Project>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -3,6 +3,29 @@
   <!-- Recurse up. -->
   <Import Project="$(MSBuildThisFileDirectory)..\Directory.Build.props" />
 
+  <!-- Include ConfigurationSchema.json in the package if it exists. -->
+  <PropertyGroup>
+    <ConfigurationSchemaPath>$(MSBuildProjectDirectory)\ConfigurationSchema.json</ConfigurationSchemaPath>
+    <ConfigurationSchemaExists Condition="Exists('$(ConfigurationSchemaPath)')">true</ConfigurationSchemaExists>
+  </PropertyGroup>
+
+  <ItemGroup Condition="'$(ConfigurationSchemaExists)' == 'true'">
+    <None Include="$(ConfigurationSchemaPath)"
+          Pack="True"
+          PackagePath="ConfigurationSchema.json" />
+  </ItemGroup>
+
+  <PropertyGroup Condition="'$(ConfigurationSchemaExists)' == 'true'">
+    <TargetsForTfmSpecificContentInPackage>$(TargetsForTfmSpecificContentInPackage);AddPackageTargetsInPackage</TargetsForTfmSpecificContentInPackage>
+  </PropertyGroup>
+
+  <Target Name="AddPackageTargetsInPackage">
+    <ItemGroup>
+      <TfmSpecificPackageFile Include="$(MSBuildThisFileDirectory)Common\Package.targets"
+                              PackagePath="buildTransitive\$(TargetFramework)\$(PackageId).targets" />
+    </ItemGroup>
+  </Target>
+
   <PropertyGroup>
     <IsShipping>true</IsShipping>
     <IsPackable>true</IsPackable>

--- a/src/ReverseProxy/Configuration/PassiveHealthCheckConfig.cs
+++ b/src/ReverseProxy/Configuration/PassiveHealthCheckConfig.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
+using Yarp.ReverseProxy.Model;
 
 namespace Yarp.ReverseProxy.Configuration;
 
@@ -21,7 +22,7 @@ public sealed record PassiveHealthCheckConfig
     public string? Policy { get; init; }
 
     /// <summary>
-    /// Destination reactivation period after which an unhealthy destination is considered healthy again.
+    /// Destination reactivation period after which an unhealthy destination reverts back to <see cref="DestinationHealth.Unknown"/>.
     /// </summary>
     public TimeSpan? ReactivationPeriod { get; init; }
 

--- a/src/ReverseProxy/Configuration/RouteHeader.cs
+++ b/src/ReverseProxy/Configuration/RouteHeader.cs
@@ -20,7 +20,7 @@ public sealed record RouteHeader
 
     /// <summary>
     /// A collection of acceptable header values used during routing. Only one value must match.
-    /// The list must not be empty unless using <see cref="HeaderMatchMode.Exists"/> or <see cref="HeaderMatchMode.NotExists"/>.
+    /// The list must not be empty unless when using <see cref="HeaderMatchMode.Exists"/> or <see cref="HeaderMatchMode.NotExists"/>.
     /// </summary>
     public IReadOnlyList<string>? Values { get; init; }
 

--- a/src/ReverseProxy/Configuration/RouteHeader.cs
+++ b/src/ReverseProxy/Configuration/RouteHeader.cs
@@ -20,7 +20,7 @@ public sealed record RouteHeader
 
     /// <summary>
     /// A collection of acceptable header values used during routing. Only one value must match.
-    /// The list must not be empty unless when using <see cref="HeaderMatchMode.Exists"/> or <see cref="HeaderMatchMode.NotExists"/>.
+    /// The list must not be empty unless using <see cref="HeaderMatchMode.Exists"/> or <see cref="HeaderMatchMode.NotExists"/>.
     /// </summary>
     public IReadOnlyList<string>? Values { get; init; }
 

--- a/src/ReverseProxy/Configuration/SessionAffinityConfig.cs
+++ b/src/ReverseProxy/Configuration/SessionAffinityConfig.cs
@@ -30,7 +30,6 @@ public sealed record SessionAffinityConfig
     /// Identifies the name of the field where the affinity value is stored.
     /// For the cookie affinity policy this will be the cookie name.
     /// For the header affinity policy this will be the header name.
-    /// The policy will give its own default if no value is set.
     /// This value should be unique across clusters to avoid affinity conflicts.
     /// https://github.com/dotnet/yarp/issues/976
     /// This field is required.

--- a/src/ReverseProxy/ConfigurationSchema.json
+++ b/src/ReverseProxy/ConfigurationSchema.json
@@ -123,7 +123,8 @@
                         },
                         "required": [
                           "Name"
-                        ]
+                        ],
+                        "additionalProperties": false
                       }
                     },
                     "QueryParameters": {
@@ -160,10 +161,24 @@
                         },
                         "required": [
                           "Name"
-                        ]
+                        ],
+                        "additionalProperties": false
                       }
                     }
-                  }
+                  },
+                  "additionalProperties": false,
+                  "anyOf": [
+                    {
+                      "required": [
+                        "Path"
+                      ]
+                    },
+                    {
+                      "required": [
+                        "Hosts"
+                      ]
+                    }
+                  ]
                 },
                 "Metadata": {
                   "type": [ "object", "null" ],
@@ -843,7 +858,8 @@
               "required": [
                 "ClusterId",
                 "Match"
-              ]
+              ],
+              "additionalProperties": false
             }
           }
         },
@@ -881,6 +897,7 @@
                           }
                         }
                       },
+                      "additionalProperties": false,
                       "required": [
                         "Address"
                       ]
@@ -996,9 +1013,11 @@
                           "type": [ "boolean", "null" ],
                           "description": "Specifies whether a cookie is essential for the application to function correctly. If true then consent policy checks may be bypassed."
                         }
-                      }
+                      },
+                      "additionalProperties": false
                     }
                   },
+                  "additionalProperties": false,
                   "required": [
                     "AffinityKeyName"
                   ]
@@ -1051,7 +1070,8 @@
                           "type": [ "string", "null" ],
                           "description": "Query string to append to the probe, including the leading '?'."
                         }
-                      }
+                      },
+                      "additionalProperties": false
                     },
                     "Passive": {
                       "type": [ "object", "null" ],
@@ -1081,7 +1101,8 @@
                           "pattern": "^-?\\d*?\\.?\\d\\d:\\d\\d:\\d\\d\\.?\\d{0,7}$",
                           "description": "Period after which an unhealthy destination reverts back to an Unknown health state."
                         }
-                      }
+                      },
+                      "additionalProperties": false
                     },
                     "AvailableDestinationsPolicy": {
                       "anyOf": [
@@ -1097,7 +1118,8 @@
                         }
                       ]
                     }
-                  }
+                  },
+                  "additionalProperties": false
                 },
                 "HttpClient": {
                   "type": [ "object", "null" ],
@@ -1150,9 +1172,11 @@
                           "description": "If true, sends CredentialCache.DefaultCredentials with requests.",
                           "default": false
                         }
-                      }
+                      },
+                      "additionalProperties": false
                     }
-                  }
+                  },
+                  "additionalProperties": false
                 },
                 "HttpRequest": {
                   "type": [ "object", "null" ],
@@ -1183,7 +1207,8 @@
                       "type": [ "boolean", "null" ],
                       "description": "Determines if response buffering is allowed."
                     }
-                  }
+                  },
+                  "additionalProperties": false
                 },
                 "Metadata": {
                   "type": [ "object", "null" ],
@@ -1192,7 +1217,8 @@
                     "type": "string"
                   }
                 }
-              }
+              },
+              "additionalProperties": false
             }
           }
         }

--- a/src/ReverseProxy/ConfigurationSchema.json
+++ b/src/ReverseProxy/ConfigurationSchema.json
@@ -19,54 +19,53 @@
                   "description": "Name of the cluster this route points to."
                 },
                 "Order": {
-                  "type": "number",
+                  "type": [ "number", "null" ],
                   "description": "Order value for this route. Routes with lower numbers take precedence over higher numbers."
                 },
                 "MaxRequestBodySize": {
-                  "type": "number",
+                  "type": [ "number", "null" ],
                   "description": "An optional override for how large request bodies can be in bytes."
                 },
                 "AuthorizationPolicy": {
-                  "type": "string",
+                  "type": [ "string", "null" ],
                   "description": "Specifies which authorization policy applies, e.g. 'Default' or 'Anonymous'."
                 },
                 "RateLimiterPolicy": {
-                  "type": "string",
+                  "type": [ "string", "null" ],
                   "description": "The name of the RateLimiterPolicy to apply to this route."
                 },
                 "OutputCachePolicy": {
-                  "type": "string",
+                  "type": [ "string", "null" ],
                   "description": "The name of the OutputCachePolicy to apply to this route."
                 },
                 "Timeout": {
-                  "type": "string",
+                  "type": [ "string", "null" ],
                   "pattern": "^-?\\d*?\\.?\\d\\d:\\d\\d:\\d\\d\\.?\\d{0,7}$",
                   "description": "The Timeout to apply to this route. This overrides any system defaults. Setting both Timeout and TimeoutPolicy is an error."
                 },
                 "TimeoutPolicy": {
-                  "type": "string",
+                  "type": [ "string", "null" ],
                   "description": "Specifies which timeout policy applies, e.g. 'Default' or 'Disable'. Setting both Timeout and TimeoutPolicy is an error."
                 },
                 "CorsPolicy": {
-                  "type": "string",
+                  "type": [ "string", "null" ],
                   "description": "Specifies which CORS policy applies, e.g. 'Default' or 'Disable'."
                 },
                 "Match": {
                   "type": "object",
                   "properties": {
                     "Path": {
-                      "type": "string",
+                      "type": [ "string", "null" ],
                       "description": "Path pattern using ASP.NET route template syntax, e.g. '/something/{**remainder}'"
                     },
                     "Hosts": {
-                      "type": "array",
+                      "type": [ "array", "null" ],
                       "description": "Only match requests with the given Host header. Supports wildcards and ports. For unicode host names, do not use punycode.",
                       "items": {
                         "type": "string"
                       }
                     },
                     "Methods": {
-                      "type": "array",
                       "description": "Allowed HTTP methods.",
                       "items": {
                         "anyOf": [
@@ -84,13 +83,13 @@
                             ]
                           },
                           {
-                            "type": "string"
+                            "type": [ "array", "null" ]
                           }
                         ]
                       }
                     },
                     "Headers": {
-                      "type": "array",
+                      "type": [ "array", "null" ],
                       "description": "List of header match conditions.",
                       "items": {
                         "type": "object",
@@ -128,7 +127,7 @@
                       }
                     },
                     "QueryParameters": {
-                      "type": "array",
+                      "type": [ "array", "null" ],
                       "description": "List of query string match conditions.",
                       "items": {
                         "type": "object",
@@ -167,20 +166,20 @@
                   }
                 },
                 "Metadata": {
-                  "type": "object",
+                  "type": [ "object", "null" ],
                   "description": "Arbitrary key-value pairs for custom route logic.",
                   "additionalProperties": {
                     "type": "string"
                   }
                 },
                 "Transforms": {
-                  "type": "array",
+                  "type": [ "array", "null" ],
                   "description": "List of transform objects for request customization.",
                   "items": {
                     "description": "A single transform definition.",
                     "anyOf": [
                       {
-                        "type": "object",
+                        "type": [ "object", "null" ],
                         "$comment": "Fallback that matches any custom user-defined transforms.",
                         "properties": {
                           "RequestHeadersCopy": false,
@@ -884,16 +883,16 @@
                           "description": "Destination address (must include scheme)."
                         },
                         "Health": {
-                          "type": "string",
+                          "type": [ "string", "null" ],
                           "format": "iri",
                           "description": "Optional override URL accepting active health check probes."
                         },
                         "Host": {
-                          "type": "string",
+                          "type": [ "string", "null" ],
                           "description": "Optional fallback host header value used if a host is not already specified by request transforms."
                         },
                         "Metadata": {
-                          "type": "object",
+                          "type": [ "object", "null" ],
                           "description": "Arbitrary key-value pairs for custom destination logic.",
                           "additionalProperties": {
                             "type": "string"
@@ -919,17 +918,17 @@
                       ]
                     },
                     {
-                      "type": "string"
+                      "type": [ "string", "null" ]
                     }
                   ],
                   "description": "Determines traffic distribution among destinations."
                 },
                 "SessionAffinity": {
-                  "type": "object",
+                  "type": [ "object", "null" ],
                   "description": "Session affinity is a mechanism to bind (affinitize) a causally related request sequence to the destination that handled the first request when the load is balanced among several destinations.",
                   "properties": {
                     "Enabled": {
-                      "type": "boolean"
+                      "type": [ "boolean", "null" ]
                     },
                     "Policy": {
                       "anyOf": [
@@ -943,7 +942,7 @@
                           ]
                         },
                         {
-                          "type": "string"
+                          "type": [ "string", "null" ]
                         }
                       ],
                       "description": "Determines how the session will be stored and retrieved."
@@ -958,7 +957,7 @@
                           ]
                         },
                         {
-                          "type": "string"
+                          "type": [ "string", "null" ]
                         }
                       ],
                       "description": "Strategy for handling a missing destination for an affinitized request."
@@ -968,32 +967,28 @@
                       "description": "Identifies the name of the field where the affinity value is stored (cookie or header name)."
                     },
                     "Cookie": {
-                      "type": "object",
+                      "type": [ "object", "null" ],
                       "properties": {
-                        "Name": {
-                          "type": "string",
-                          "description": "Specifies the name of the cookie."
-                        },
                         "Domain": {
-                          "type": "string",
+                          "type": [ "string", "null" ],
                           "description": "Specifies the domain of the cookie."
                         },
                         "Path": {
-                          "type": "string",
+                          "type": [ "string", "null" ],
                           "description": "Specifies the path of the cookie."
                         },
                         "Expiration": {
-                          "type": "string",
+                          "type": [ "string", "null" ],
                           "pattern": "^-?\\d*?\\.?\\d\\d:\\d\\d:\\d\\d\\.?\\d{0,7}$",
                           "description": "Specifies the expiration of the cookie."
                         },
                         "MaxAge": {
-                          "type": "string",
+                          "type": [ "string", "null" ],
                           "pattern": "^-?\\d*?\\.?\\d\\d:\\d\\d:\\d\\d\\.?\\d{0,7}$",
                           "description": "Specifies the maximum age of the cookie."
                         },
                         "SecurePolicy": {
-                          "type": "string",
+                          "type": [ "string", "null" ],
                           "enum": [
                             "Always",
                             "None",
@@ -1002,11 +997,11 @@
                           "description": "Specifies the Secure attribute of the cookie."
                         },
                         "HttpOnly": {
-                          "type": "boolean",
+                          "type": [ "boolean", "null" ],
                           "description": "Specifies whether a cookie is accessible by client-side script."
                         },
                         "SameSite": {
-                          "type": "string",
+                          "type": [ "string", "null" ],
                           "enum": [
                             "Lax",
                             "None",
@@ -1016,7 +1011,7 @@
                           "description": "Specifies the SameSite attribute of the cookie."
                         },
                         "IsEssential": {
-                          "type": "boolean",
+                          "type": [ "boolean", "null" ],
                           "description": "Specifies whether a cookie is essential for the application to function correctly. If true then consent policy checks may be bypassed."
                         }
                       }
@@ -1027,24 +1022,24 @@
                   ]
                 },
                 "HealthCheck": {
-                  "type": "object",
+                  "type": [ "object", "null" ],
                   "description": "Health check configuration for destinations.",
                   "properties": {
                     "Active": {
-                      "type": "object",
+                      "type": [ "object", "null" ],
                       "description": "Active health checks are based on sending health probing requests.",
                       "properties": {
                         "Enabled": {
-                          "type": "boolean",
+                          "type": [ "boolean", "null" ],
                           "description": "Determines if active health checks are enabled. Defaults to false."
                         },
                         "Interval": {
-                          "type": "string",
+                          "type": [ "string", "null" ],
                           "pattern": "^-?\\d*?\\.?\\d\\d:\\d\\d:\\d\\d\\.?\\d{0,7}$",
                           "description": "Period of sending health probing requests. Defaults to '00:00:15'."
                         },
                         "Timeout": {
-                          "type": "string",
+                          "type": [ "string", "null" ],
                           "pattern": "^-?\\d*?\\.?\\d\\d:\\d\\d:\\d\\d\\.?\\d{0,7}$",
                           "description": "Period of waiting for a health check response. Defaults to '00:00:10'."
                         },
@@ -1057,31 +1052,30 @@
                               ]
                             },
                             {
-                              "type": "string"
+                              "type": [ "string", "null" ]
                             }
                           ],
                           "description": "Determines the health check policy."
                         },
                         "Path": {
-                          "type": "string",
+                          "type": [ "string", "null" ],
                           "description": "HTTP health check endpoint path. Defaults to '/'."
                         },
                         "Query": {
-                          "type": "string",
+                          "type": [ "string", "null" ],
                           "description": "Query string to append to the probe, including the leading '?'."
                         }
                       }
                     },
                     "Passive": {
-                      "type": "object",
+                      "type": [ "object", "null" ],
                       "description": "Passive health checks are based on observing the health of the responses from the destination.",
                       "properties": {
                         "Enabled": {
-                          "type": "boolean",
+                          "type": [ "boolean", "null" ],
                           "description": "Determines if passive health checks are enabled. Default false."
                         },
                         "Policy": {
-                          "type": "string",
                           "anyOf": [
                             {
                               "type": "string",
@@ -1090,13 +1084,13 @@
                               ]
                             },
                             {
-                              "type": "string"
+                              "type": [ "string", "null" ]
                             }
                           ],
                           "description": "Determines the health check policy."
                         },
                         "ReactivationPeriod": {
-                          "type": "string",
+                          "type": [ "string", "null" ],
                           "pattern": "^-?\\d*?\\.?\\d\\d:\\d\\d:\\d\\d\\.?\\d{0,7}$",
                           "description": "Period after which an unhealthy destination reverts back to an Unknown health state."
                         }
@@ -1112,14 +1106,14 @@
                           ]
                         },
                         {
-                          "type": "string"
+                          "type": [ "string", "null" ]
                         }
                       ]
                     }
                   }
                 },
                 "HttpClient": {
-                  "type": "object",
+                  "type": [ "object", "null" ],
                   "description": "Configuration for outbound HTTP connections.",
                   "properties": {
                     "SSLProtocols": {
@@ -1130,40 +1124,40 @@
                       }
                     },
                     "DangerousAcceptAnyServerCertificate": {
-                      "type": "boolean",
+                      "type": [ "boolean", "null" ],
                       "description": "Determines whether the server's SSL certificate validity is checked by the client. Setting it to true completely disables validation. Default value is false."
                     },
                     "MaxConnectionsPerServer": {
-                      "type": "number",
+                      "type": [ "number", "null" ],
                       "description": "Specifies the maximum number of connections per server."
                     },
                     "EnableMultipleHttp2Connections": {
-                      "type": "boolean",
+                      "type": [ "boolean", "null" ],
                       "description": "Determines if multiple HTTP/2 connections are enabled. Defaults to true."
                     },
                     "RequestHeaderEncoding": {
-                      "type": "string",
+                      "type": [ "string", "null" ],
                       "description": "Specifies the encoding of request headers, e.g. 'utf-8'."
                     },
                     "ResponseHeaderEncoding": {
-                      "type": "string",
+                      "type": [ "string", "null" ],
                       "description": "Specifies the encoding of response headers, e.g. 'utf-8'."
                     },
                     "WebProxy": {
-                      "type": "object",
+                      "type": [ "object", "null" ],
                       "description": "Config used to construct a System.Net.WebProxy instance.",
                       "properties": {
                         "Address": {
-                          "type": "string",
+                          "type": [ "string", "null" ],
                           "format": "iri",
                           "description": "The URI of the proxy server."
                         },
                         "BypassOnLocal": {
-                          "type": "boolean",
+                          "type": [ "boolean", "null" ],
                           "description": "If true, bypasses the proxy for local addresses. Defaults to false."
                         },
                         "UseDefaultCredentials": {
-                          "type": "boolean",
+                          "type": [ "boolean", "null" ],
                           "description": "If true, sends CredentialCache.DefaultCredentials with requests. Defaults to false."
                         }
                       }
@@ -1171,20 +1165,20 @@
                   }
                 },
                 "HttpRequest": {
-                  "type": "object",
+                  "type": [ "object", "null" ],
                   "description": "Options controlling requests sent to destinations.",
                   "properties": {
                     "ActivityTimeout": {
-                      "type": "string",
+                      "type": [ "string", "null" ],
                       "pattern": "^-?\\d*?\\.?\\d\\d:\\d\\d:\\d\\d\\.?\\d{0,7}$",
                       "description": "Specifies how long a request is allowed to remain idle between any operation completing, after which it will be canceled. Default is 100 seconds."
                     },
                     "Version": {
-                      "type": "string",
+                      "type": [ "string", "null" ],
                       "description": "Preferred version of the outgoing request. Defaults to HTTP/2."
                     },
                     "VersionPolicy": {
-                      "type": "string",
+                      "type": [ "string", "null" ],
                       "description": "The policy applied to version selection, e.g. whether to prefer downgrades, upgrades or request an exact version. The default is `RequestVersionOrLower`.",
                       "enum": [
                         "RequestVersionExact",
@@ -1193,13 +1187,13 @@
                       ]
                     },
                     "AllowResponseBuffering": {
-                      "type": "boolean",
+                      "type": [ "boolean", "null" ],
                       "description": "Determines if response buffering is allowed."
                     }
                   }
                 },
                 "Metadata": {
-                  "type": "object",
+                  "type": [ "object", "null" ],
                   "description": "Arbitrary key-value pairs for custom cluster logic.",
                   "additionalProperties": {
                     "type": "string"

--- a/src/ReverseProxy/ConfigurationSchema.json
+++ b/src/ReverseProxy/ConfigurationSchema.json
@@ -41,7 +41,7 @@
                 "Timeout": {
                   "type": [ "string", "null" ],
                   "pattern": "^-?\\d*?\\.?\\d\\d:\\d\\d:\\d\\d\\.?\\d{0,7}$",
-                  "description": "The Timeout to apply to this route. This overrides any system defaults. Setting both Timeout and TimeoutPolicy is an error."
+                  "description": "The Timeout to apply to this route. This overrides any system defaults. Setting both Timeout and TimeoutPolicy is an error. Format: 'hh:mm:ss'."
                 },
                 "TimeoutPolicy": {
                   "type": [ "string", "null" ],
@@ -979,12 +979,12 @@
                         "Expiration": {
                           "type": [ "string", "null" ],
                           "pattern": "^-?\\d*?\\.?\\d\\d:\\d\\d:\\d\\d\\.?\\d{0,7}$",
-                          "description": "Specifies the expiration of the cookie."
+                          "description": "Specifies the expiration of the cookie. Format: 'hh:mm:ss'."
                         },
                         "MaxAge": {
                           "type": [ "string", "null" ],
                           "pattern": "^-?\\d*?\\.?\\d\\d:\\d\\d:\\d\\d\\.?\\d{0,7}$",
-                          "description": "Specifies the maximum age of the cookie."
+                          "description": "Specifies the maximum age of the cookie. Format: 'hh:mm:ss'."
                         },
                         "SecurePolicy": {
                           "type": [ "string", "null" ],
@@ -1038,13 +1038,13 @@
                         "Interval": {
                           "type": [ "string", "null" ],
                           "pattern": "^-?\\d*?\\.?\\d\\d:\\d\\d:\\d\\d\\.?\\d{0,7}$",
-                          "description": "Period of sending health probing requests.",
+                          "description": "Period of sending health probing requests. Format: 'hh:mm:ss'.",
                           "default": "00:00:15"
                         },
                         "Timeout": {
                           "type": [ "string", "null" ],
                           "pattern": "^-?\\d*?\\.?\\d\\d:\\d\\d:\\d\\d\\.?\\d{0,7}$",
-                          "description": "Period of waiting for a health check response.",
+                          "description": "Period of waiting for a health check response. Format: 'hh:mm:ss'.",
                           "default": "00:00:10"
                         },
                         "Policy": {
@@ -1099,7 +1099,7 @@
                         "ReactivationPeriod": {
                           "type": [ "string", "null" ],
                           "pattern": "^-?\\d*?\\.?\\d\\d:\\d\\d:\\d\\d\\.?\\d{0,7}$",
-                          "description": "Period after which an unhealthy destination reverts back to an Unknown health state."
+                          "description": "Period after which an unhealthy destination reverts back to an Unknown health state. Format: 'hh:mm:ss'."
                         }
                       },
                       "additionalProperties": false
@@ -1156,7 +1156,7 @@
                     },
                     "WebProxy": {
                       "type": [ "object", "null" ],
-                      "description": "Config used to construct a System.Net.WebProxy instance.",
+                      "description": "Config used to construct a System.Net.WebProxy instance used for outgoing requests.",
                       "properties": {
                         "Address": {
                           "type": [ "string", "null" ],
@@ -1185,7 +1185,7 @@
                     "ActivityTimeout": {
                       "type": [ "string", "null" ],
                       "pattern": "^-?\\d*?\\.?\\d\\d:\\d\\d:\\d\\d\\.?\\d{0,7}$",
-                      "description": "Specifies how long a request is allowed to remain idle between any operation completing, after which it will be canceled.",
+                      "description": "Specifies how long a request is allowed to remain idle between any operation completing, after which it will be canceled. Format: 'hh:mm:ss'.",
                       "default": "00:01:40"
                     },
                     "Version": {

--- a/src/ReverseProxy/ConfigurationSchema.json
+++ b/src/ReverseProxy/ConfigurationSchema.json
@@ -1,0 +1,1006 @@
+{
+    "$id": "https://yarp.dot.net/reverseproxy/YarpConfigSchema.json",
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "YARP Configuration Schema",
+    "description": "https://yarp.dot.net",
+    "type": "object",
+    "properties": {
+        "Urls": {
+            "type": "string",
+            "description": "One or more listening URLs separated by semicolons."
+        },
+        "Logging": {
+            "type": "object",
+            "description": "Logging configuration settings.",
+            "properties": {
+                "LogLevel": {
+                    "type": "object",
+                    "description": "Maps logging providers to log levels.",
+                    "additionalProperties": {
+                        "type": "string"
+                    }
+                }
+            },
+            "additionalProperties": true
+        },
+        "ReverseProxy": {
+            "type": "object",
+            "description": "Reverse proxy configuration for routes and clusters.",
+            "properties": {
+                "Routes": {
+                    "type": "object",
+                    "description": "Named routes that direct incoming requests to clusters.",
+                    "patternProperties": {
+                        "^[A-Za-z0-9_-]+$": {
+                            "type": "object",
+                            "properties": {
+                                "ClusterId": {
+                                    "type": "string",
+                                    "description": "Name of the cluster this route points to."
+                                },
+                                "Order": {
+                                    "type": "number",
+                                    "description": "Determines route priority; lower values match first."
+                                },
+                                "MaxRequestBodySize": {
+                                    "type": "number",
+                                    "description": "Optional override for max request body size in bytes."
+                                },
+                                "AuthorizationPolicy": {
+                                    "type": "string",
+                                    "description": "Specifies which authorization policy applies, e.g. 'Default' or 'Anonymous'."
+                                },
+                                "CorsPolicy": {
+                                    "type": "string",
+                                    "description": "Specifies which CORS policy applies, e.g. 'Default' or 'Disable'."
+                                },
+                                "Match": {
+                                    "type": "object",
+                                    "properties": {
+                                        "Path": {
+                                            "type": "string",
+                                            "description": "Path pattern using ASP.NET route template syntax, e.g. '/something/{**remainder}'"
+                                        },
+                                        "Hosts": {
+                                            "type": "array",
+                                            "description": "Host names to match, e.g. 'www.aaaa.com'",
+                                            "items": {
+                                                "type": "string"
+                                            }
+                                        },
+                                        "Methods": {
+                                            "type": "array",
+                                            "description": "Allowed HTTP methods, e.g. 'GET'",
+                                            "items": {
+                                                "type": "string"
+                                            }
+                                        },
+                                        "Headers": {
+                                            "type": "array",
+                                            "description": "List of header match conditions.",
+                                            "items": {
+                                                "type": "object",
+                                                "properties": {
+                                                    "Name": {
+                                                        "type": "string",
+                                                        "description": "Header name"
+                                                    },
+                                                    "Values": {
+                                                        "type": "array",
+                                                        "description": "Matches against any of these values",
+                                                        "items": {
+                                                            "type": "string"
+                                                        }
+                                                    },
+                                                    "Mode": {
+                                                        "type": "string",
+                                                        "description": "How the header values should be matched",
+                                                        "enum": [
+                                                            "ExactHeader",
+                                                            "HeaderPrefix",
+                                                            "Exists",
+                                                            "Contains",
+                                                            "NotContains",
+                                                            "NotExists"
+                                                        ]
+                                                    },
+                                                    "IsCaseSensitive": {
+                                                        "type": "boolean"
+                                                    }
+                                                },
+                                                "required": [
+                                                    "Name"
+                                                ]
+                                            }
+                                        },
+                                        "QueryParameters": {
+                                            "type": "array",
+                                            "description": "List of query string match conditions.",
+                                            "items": {
+                                                "type": "object",
+                                                "properties": {
+                                                    "Name": {
+                                                        "type": "string",
+                                                        "description": "Name of the query parameter"
+                                                    },
+                                                    "Values": {
+                                                        "type": "array",
+                                                        "description": "Matches are against any of the specified values",
+                                                        "items": {
+                                                            "type": "string"
+                                                        }
+                                                    },
+                                                    "Mode": {
+                                                        "type": "string",
+                                                        "enum": [
+                                                            "Exact",
+                                                            "Prefix",
+                                                            "Exists",
+                                                            "Contains",
+                                                            "NotContains"
+                                                        ]
+                                                    },
+                                                    "IsCaseSensitive": {
+                                                        "type": "boolean"
+                                                    }
+                                                },
+                                                "required": [
+                                                    "Name"
+                                                ]
+                                            }
+                                        }
+                                    },
+                                    "additionalProperties": false
+                                },
+                                "Metadata": {
+                                    "type": "object",
+                                    "description": "Arbitrary key-value pairs for custom route logic.",
+                                    "additionalProperties": {
+                                        "type": "string"
+                                    }
+                                },
+                                "Transforms": {
+                                    "type": "array",
+                                    "description": "List of transform objects for request customization.",
+                                    "items": {
+                                        "description": "A single transform definition.",
+                                        "anyOf": [
+                                            {
+                                                "type": "object",
+                                                "description": "Transform controlling whether request headers are copied from the original request.",
+                                                "properties": {
+                                                    "RequestHeadersCopy": {
+                                                        "type": "boolean",
+                                                        "description": "If true, copies all request headers to outbound request."
+                                                    }
+                                                },
+                                                "additionalProperties": false,
+                                                "required": [
+                                                    "RequestHeadersCopy"
+                                                ]
+                                            },
+                                            {
+                                                "type": "object",
+                                                "description": "Transform to control whether the original host header is preserved.",
+                                                "properties": {
+                                                    "RequestHeaderOriginalHost": {
+                                                        "type": "boolean",
+                                                        "description": "If true, preserve the original Host header; otherwise the destination's host is used."
+                                                    }
+                                                },
+                                                "additionalProperties": false,
+                                                "required": [
+                                                    "RequestHeaderOriginalHost"
+                                                ]
+                                            },
+                                            {
+                                                "type": "object",
+                                                "description": "Transform for setting, appending, or removing a request header.",
+                                                "properties": {
+                                                    "RequestHeader": {
+                                                        "type": "string",
+                                                        "description": "The header name to operate on."
+                                                    },
+                                                    "Set": {
+                                                        "type": "string",
+                                                        "description": "Value to set in the given request header."
+                                                    },
+                                                    "Append": {
+                                                        "type": "string",
+                                                        "description": "Value to append to the given request header."
+                                                    },
+                                                    "Remove": {
+                                                        "type": "boolean",
+                                                        "description": "Removes the header if true."
+                                                    }
+                                                },
+                                                "additionalProperties": false,
+                                                "required": [
+                                                    "RequestHeader"
+                                                ]
+                                            },
+                                            {
+                                                "type": "object",
+                                                "description": "Transform that removes a specified prefix from the request path.",
+                                                "properties": {
+                                                    "PathRemovePrefix": {
+                                                        "type": "string",
+                                                        "description": "Prefix to remove from the existing request path."
+                                                    }
+                                                },
+                                                "additionalProperties": false,
+                                                "required": [
+                                                    "PathRemovePrefix"
+                                                ]
+                                            },
+                                            {
+                                                "type": "object",
+                                                "description": "Transform that replaces the entire request path with the provided value.",
+                                                "properties": {
+                                                    "PathSet": {
+                                                        "type": "string",
+                                                        "description": "Sets the request path to this value."
+                                                    }
+                                                },
+                                                "additionalProperties": false,
+                                                "required": [
+                                                    "PathSet"
+                                                ]
+                                            },
+                                            {
+                                                "type": "object",
+                                                "description": "Transform that adds or modifies path prefix.",
+                                                "properties": {
+                                                    "PathPrefix": {
+                                                        "type": "string",
+                                                        "description": "Path prefix to add if not already present."
+                                                    }
+                                                },
+                                                "additionalProperties": false,
+                                                "required": [
+                                                    "PathPrefix"
+                                                ]
+                                            },
+                                            {
+                                                "type": "object",
+                                                "description": "Transform that copies a parameter from the route and adds it as a query parameter.",
+                                                "properties": {
+                                                    "QueryParameterFromRoute": {
+                                                        "type": "string",
+                                                        "description": "Specifies the query parameter name to add or replace."
+                                                    },
+                                                    "RouteParameter": {
+                                                        "type": "string",
+                                                        "description": "Name of the route parameter to copy from."
+                                                    }
+                                                },
+                                                "additionalProperties": false,
+                                                "required": [
+                                                    "QueryParameterFromRoute",
+                                                    "RouteParameter"
+                                                ]
+                                            },
+                                            {
+                                                "type": "object",
+                                                "description": "Transform that replaces the entire request path using a pattern template, replacing {} segments with the route value",
+                                                "properties": {
+                                                    "PathPattern": {
+                                                        "type": "string",
+                                                        "description": "A path template starting with a '/'"
+                                                    }
+                                                },
+                                                "additionalProperties": false,
+                                                "required": [
+                                                    "PathPattern"
+                                                ]
+                                            },
+                                            {
+                                                "type": "object",
+                                                "description": "Adds or replaces parameters in the request query string",
+                                                "properties": {
+                                                    "QueryValueParameter": {
+                                                        "type": "string",
+                                                        "description": "Name of a query string parameter"
+                                                    },
+                                                    "Set": {
+                                                        "type": "string",
+                                                        "description": "Value to set in the given query parameter."
+                                                    },
+                                                    "Append": {
+                                                        "type": "string",
+                                                        "description": "Value to append to the given query parameter."
+                                                    }
+                                                },
+                                                "additionalProperties": false,
+                                                "required": [
+                                                    "QueryValueParameter"
+                                                ]
+                                            },
+                                            {
+                                                "type": "object",
+                                                "description": "Adds or replaces a query string parameter with a value from the route configuration",
+                                                "properties": {
+                                                    "QueryRouteParameter": {
+                                                        "type": "string",
+                                                        "description": "Name of a query string parameter"
+                                                    },
+                                                    "Set": {
+                                                        "type": "string",
+                                                        "description": "Route value to set in the given query parameter."
+                                                    },
+                                                    "Append": {
+                                                        "type": "string",
+                                                        "description": "Route value to append to the given query parameter."
+                                                    }
+                                                },
+                                                "additionalProperties": false,
+                                                "required": [
+                                                    "QueryRouteParameter"
+                                                ]
+                                            },
+                                            {
+                                                "type": "object",
+                                                "description": "Removes the specified parameter from the request query string",
+                                                "properties": {
+                                                    "QueryRemoveParameter": {
+                                                        "type": "string",
+                                                        "description": "Name of a query string parameter"
+                                                    }
+                                                },
+                                                "additionalProperties": false,
+                                                "required": [
+                                                    "QueryRemoveParameter"
+                                                ]
+                                            },
+                                            {
+                                                "type": "object",
+                                                "description": "Adds or replaces parameters in the request query string",
+                                                "properties": {
+                                                    "HttpMethodChange": {
+                                                        "type": "string",
+                                                        "description": "The http method to replace"
+                                                    },
+                                                    "Set": {
+                                                        "type": "string",
+                                                        "description": "The new HTTP method"
+                                                    }
+                                                },
+                                                "additionalProperties": false,
+                                                "required": [
+                                                    "HttpMethodChange"
+                                                ]
+                                            },
+                                            {
+                                                "type": "object",
+                                                "description": "Adds or replaces a header with a value from the route configuration",
+                                                "properties": {
+                                                    "RequestHeaderRouteValue": {
+                                                        "type": "string",
+                                                        "description": "Name of a query string parameter"
+                                                    },
+                                                    "Set": {
+                                                        "type": "string",
+                                                        "description": "Route value to set in the given header."
+                                                    },
+                                                    "Append": {
+                                                        "type": "string",
+                                                        "description": "Route value to append to the given header."
+                                                    }
+                                                },
+                                                "additionalProperties": false,
+                                                "required": [
+                                                    "RequestHeaderRouteValue"
+                                                ]
+                                            },
+                                            {
+                                                "type": "object",
+                                                "description": "Removes the specified header from the request",
+                                                "properties": {
+                                                    "RequestHeaderRemove": {
+                                                        "type": "string",
+                                                        "description": "The header name"
+                                                    }
+                                                },
+                                                "additionalProperties": false,
+                                                "required": [
+                                                    "RequestHeaderRemove"
+                                                ]
+                                            },
+                                            {
+                                                "type": "object",
+                                                "description": "YARP copies most request headers to the proxy request by default, this transform disables RequestHeadersCopy and only copies the given headers.",
+                                                "properties": {
+                                                    "RequestHeadersAllowed": {
+                                                        "type": "string",
+                                                        "description": "A semicolon separated list of allowed header names."
+                                                    }
+                                                },
+                                                "additionalProperties": false,
+                                                "required": [
+                                                    "RequestHeadersAllowed"
+                                                ]
+                                            },
+                                            {
+                                                "type": "object",
+                                                "description": "Adds headers with information about the original client request",
+                                                "properties": {
+                                                    "X-Forwarded": {
+                                                        "type": "string",
+                                                        "description": "Default action to apply to all X-Forwarded-* headers",
+                                                        "enum": [
+                                                            "Set",
+                                                            "Append",
+                                                            "Remove",
+                                                            "Off"
+                                                        ]
+                                                    },
+                                                    "For": {
+                                                        "type": "string",
+                                                        "description": "Action to apply to the 'For' header",
+                                                        "enum": [
+                                                            "Set",
+                                                            "Append",
+                                                            "Remove",
+                                                            "Off"
+                                                        ]
+                                                    },
+                                                    "Proto": {
+                                                        "type": "string",
+                                                        "description": "Action to apply to the 'Proto' header",
+                                                        "enum": [
+                                                            "Set",
+                                                            "Append",
+                                                            "Remove",
+                                                            "Off"
+                                                        ]
+                                                    },
+                                                    "Host": {
+                                                        "type": "string",
+                                                        "description": "Action to apply to the 'Host' header",
+                                                        "enum": [
+                                                            "Set",
+                                                            "Append",
+                                                            "Remove",
+                                                            "Off"
+                                                        ]
+                                                    },
+                                                    "Prefix": {
+                                                        "type": "string",
+                                                        "description": "Action to apply to the 'Prefix' header",
+                                                        "enum": [
+                                                            "Set",
+                                                            "Append",
+                                                            "Remove",
+                                                            "Off"
+                                                        ]
+                                                    },
+                                                    "HeaderPrefix": {
+                                                        "type": "string",
+                                                        "description": "The header name prefix, defaults to 'X-Forwarded-`"
+                                                    }
+                                                },
+                                                "additionalProperties": false,
+                                                "required": [
+                                                    "X-Forwarded"
+                                                ]
+                                            },
+                                            {
+                                                "type": "object",
+                                                "description": "Adds a header with information about the original client request",
+                                                "properties": {
+                                                    "Forwarded": {
+                                                        "type": "string",
+                                                        "description": "A comma separated list containing any of these values: 'for,by,proto,host'"
+                                                    },
+                                                    "ForFormat": {
+                                                        "type": "string",
+                                                        "description": "Format to apply to the 'For' header",
+                                                        "enum": [
+                                                            "Random",
+                                                            "RandomAndPort",
+                                                            "RandomAndRandomPort",
+                                                            "Unknown",
+                                                            "UnknownAndPort",
+                                                            "UnknownAndRandomPort",
+                                                            "Ip",
+                                                            "IpAndPort",
+                                                            "IpAndRandomPort"
+                                                        ]
+                                                    },
+                                                    "ByFormat": {
+                                                        "type": "string",
+                                                        "description": "Format to apply to the 'For' header",
+                                                        "enum": [
+                                                            "Random",
+                                                            "RandomAndPort",
+                                                            "RandomAndRandomPort",
+                                                            "Unknown",
+                                                            "UnknownAndPort",
+                                                            "UnknownAndRandomPort",
+                                                            "Ip",
+                                                            "IpAndPort",
+                                                            "IpAndRandomPort"
+                                                        ]
+                                                    },
+                                                    "Action": {
+                                                        "type": "string",
+                                                        "description": "Action to apply to an existing 'Forwarded' header",
+                                                        "enum": [
+                                                            "Set",
+                                                            "Append",
+                                                            "Remove",
+                                                            "Off"
+                                                        ]
+                                                    }
+                                                },
+                                                "additionalProperties": false,
+                                                "required": [
+                                                    "Forwarded"
+                                                ]
+                                            },
+                                            {
+                                                "type": "object",
+                                                "description": "Forwards the client cert used on the inbound connection as a header to destination",
+                                                "properties": {
+                                                    "ClientCert": {
+                                                        "type": "string",
+                                                        "description": "The header name to use for the forwarded client cert"
+                                                    }
+                                                },
+                                                "additionalProperties": false,
+                                                "required": [
+                                                    "ClientCert"
+                                                ]
+                                            },
+                                            {
+                                                "type": "object",
+                                                "description": "Transform controlling whether response headers are copied from the original response.",
+                                                "properties": {
+                                                    "ResponseHeadersCopy": {
+                                                        "type": "boolean",
+                                                        "description": "If true, copies all response headers to outbound response."
+                                                    }
+                                                },
+                                                "additionalProperties": false,
+                                                "required": [
+                                                    "ResponseHeadersCopy"
+                                                ]
+                                            },
+                                            {
+                                                "type": "object",
+                                                "description": "Transform for setting, appending, or removing a response header.",
+                                                "properties": {
+                                                    "ResponseHeader": {
+                                                        "type": "string",
+                                                        "description": "The header name to operate on."
+                                                    },
+                                                    "Set": {
+                                                        "type": "string",
+                                                        "description": "Value to set in the given response header."
+                                                    },
+                                                    "Append": {
+                                                        "type": "string",
+                                                        "description": "Value to append to the given response header."
+                                                    },
+                                                    "When": {
+                                                        "type": "string",
+                                                        "enum": [
+                                                            "Success",
+                                                            "Always",
+                                                            "Failure"
+                                                        ],
+                                                        "description": "Specifies if the response header should be included for all, successful, or failure responses. Any response with a status code less than 400 is considered a success."
+                                                    }
+                                                },
+                                                "additionalProperties": false,
+                                                "required": [
+                                                    "ResponseHeader"
+                                                ]
+                                            },
+                                            {
+                                                "type": "object",
+                                                "description": "Removes the specified header from the response",
+                                                "properties": {
+                                                    "ResponseHeaderRemove": {
+                                                        "type": "string",
+                                                        "description": "The header name"
+                                                    },
+                                                    "When": {
+                                                        "type": "string",
+                                                        "enum": [
+                                                            "Success",
+                                                            "Always",
+                                                            "Failure"
+                                                        ],
+                                                        "description": "Specifies if the response header should be included for all, successful, or failure responses. Any response with a status code less than 400 is considered a success."
+                                                    }
+                                                },
+                                                "additionalProperties": false,
+                                                "required": [
+                                                    "ResponseHeaderRemove"
+                                                ]
+                                            },
+                                            {
+                                                "type": "object",
+                                                "description": "YARP copies most response headers to the proxy response by default, this transform disables ResponseHeadersCopy and only copies the given headers.",
+                                                "properties": {
+                                                    "ResponseHeadersAllowed": {
+                                                        "type": "string",
+                                                        "description": "A semicolon separated list of allowed header names."
+                                                    }
+                                                },
+                                                "additionalProperties": false,
+                                                "required": [
+                                                    "ResponseHeadersAllowed"
+                                                ]
+                                            },
+                                            {
+                                                "type": "object",
+                                                "description": "Sets whether destination trailing response headers are copied to the client",
+                                                "properties": {
+                                                    "ResponseTrailersCopy": {
+                                                        "type": "boolean",
+                                                        "description": "If true, copies all response trailers to outbound response."
+                                                    }
+                                                },
+                                                "additionalProperties": false,
+                                                "required": [
+                                                    "ResponseTrailersCopy"
+                                                ]
+                                            },
+                                            {
+                                                "type": "object",
+                                                "description": "Transform for setting, appending, or removing a response trailer.",
+                                                "properties": {
+                                                    "ResponseTrailer": {
+                                                        "type": "string",
+                                                        "description": "The trailer name to operate on."
+                                                    },
+                                                    "Set": {
+                                                        "type": "string",
+                                                        "description": "Value to set in the given response trailer."
+                                                    },
+                                                    "Append": {
+                                                        "type": "string",
+                                                        "description": "Value to append to the given response trailer."
+                                                    },
+                                                    "When": {
+                                                        "type": "string",
+                                                        "enum": [
+                                                            "Success",
+                                                            "Always",
+                                                            "Failure"
+                                                        ],
+                                                        "description": "Specifies if the response trailer should be included for all, successful, or failure responses. Any response with a status code less than 400 is considered a success."
+                                                    }
+                                                },
+                                                "additionalProperties": false,
+                                                "required": [
+                                                    "ResponseTrailer"
+                                                ]
+                                            },
+                                            {
+                                                "type": "object",
+                                                "description": "Removes the specified trailer from the response",
+                                                "properties": {
+                                                    "ResponseTrailerRemove": {
+                                                        "type": "string",
+                                                        "description": "The trailer name"
+                                                    },
+                                                    "When": {
+                                                        "type": "string",
+                                                        "enum": [
+                                                            "Success",
+                                                            "Always",
+                                                            "Failure"
+                                                        ],
+                                                        "description": "Specifies if the response trailer should be removed for all, successful, or failure responses. Any response with a status code less than 400 is considered a success."
+                                                    }
+                                                },
+                                                "additionalProperties": false,
+                                                "required": [
+                                                    "ResponseTrailerRemove"
+                                                ]
+                                            },
+                                            {
+                                                "type": "object",
+                                                "description": "YARP copies most response trailers to the proxy response by default, this transform disables ResponseTrailersCopy and only copies the given headers.",
+                                                "properties": {
+                                                    "ResponseTrailersAllowed": {
+                                                        "type": "string",
+                                                        "description": "A semicolon separated list of allowed trailer names."
+                                                    }
+                                                },
+                                                "additionalProperties": false,
+                                                "required": [
+                                                    "ResponseTrailersAllowed"
+                                                ]
+                                            }
+                                        ]
+                                    }
+                                }
+                            },
+                            "required": [
+                                "ClusterId",
+                                "Match"
+                            ],
+                            "additionalProperties": false
+                        }
+                    }
+                },
+                "Clusters": {
+                    "type": "object",
+                    "description": "Named clusters describing destinations and load-balancing.",
+                    "patternProperties": {
+                        "^[A-Za-z0-9_-]+$": {
+                            "type": "object",
+                            "properties": {
+                                "Destinations": {
+                                    "type": "object",
+                                    "description": "Named destinations where traffic is forwarded.",
+                                    "patternProperties": {
+                                        "^[A-Za-z0-9_-]+$": {
+                                            "type": "object",
+                                            "properties": {
+                                                "Address": {
+                                                    "type": "string",
+                                                    "description": "Destination address (must include scheme)."
+                                                },
+                                                "Health": {
+                                                    "type": "string",
+                                                    "description": "Optional override URL checked during active health."
+                                                }
+                                            },
+                                            "required": [
+                                                "Address"
+                                            ],
+                                            "additionalProperties": false
+                                        }
+                                    }
+                                },
+                                "LoadBalancingPolicy": {
+                                    "type": "string",
+                                    "enum": [
+                                        "PowerOfTwoChoices",
+                                        "FirstAlphabetical",
+                                        "Random",
+                                        "RoundRobin",
+                                        "LeastRequests"
+                                    ],
+                                    "description": "Determines traffic distribution among destinations."
+                                },
+                                "SessionAffinity": {
+                                    "type": "object",
+                                    "description": "Session affinity is a mechanism to bind (affinitize) a causally related request sequence to the destination that handled the first request when the load is balanced among several destinations.",
+                                    "properties": {
+                                        "Enabled": {
+                                            "type": "boolean"
+                                        },
+                                        "Policy": {
+                                            "type": "string",
+                                            "enum": [
+                                                "HashCookie",
+                                                "ArrCookie",
+                                                "Cookie",
+                                                "CustomHeader"
+                                            ],
+                                            "description": "Affinity failure policy to use if the affinity key cannot be decoded or no healthy destination found ."
+                                        },
+                                        "FailurePolicy": {
+                                            "type": "string",
+                                            "enum": [
+                                                "Redistribute",
+                                                "Return503Error"
+                                            ],
+                                            "description": "Determines how the session will be stored and retrieved."
+                                        },
+                                        "AffinityKeyName": {
+                                            "type": "string",
+                                            "description": "Affinity key used to identify the target destination."
+                                        },
+                                        "Cookie": {
+                                            "type": "object",
+                                            "properties": {
+                                                "Name": {
+                                                    "type": "string",
+                                                    "description": "Specifies the name of the cookie."
+                                                },
+                                                "Domain": {
+                                                    "type": "string",
+                                                    "description": "Specifies the domain of the cookie."
+                                                },
+                                                "Path": {
+                                                    "type": "string",
+                                                    "description": "Specifies the path of the cookie."
+                                                },
+                                                "Expiration": {
+                                                    "type": "string",
+                                                    "description": "Specifies the expiration of the cookie."
+                                                },
+                                                "MaxAge": {
+                                                    "type": "string",
+                                                    "description": "Specifies the maximum age of the cookie."
+                                                },
+                                                "SecurePolicy": {
+                                                    "type": "string",
+                                                    "enum": [
+                                                        "Always",
+                                                        "None",
+                                                        "SameAsRequest"
+                                                    ],
+                                                    "description": "Specifies the Secure attribute of the cookie."
+                                                },
+                                                "HttpOnly": {
+                                                    "type": "boolean",
+                                                    "description": "Specifies whether a cookie is accessible by client-side script."
+                                                },
+                                                "SameSite": {
+                                                    "type": "string",
+                                                    "enum": [
+                                                        "Lax",
+                                                        "None",
+                                                        "Strict",
+                                                        "Unspecified"
+                                                    ],
+                                                    "description": "Specifies the SameSite attribute of the cookie."
+                                                },
+                                                "IsEssential": {
+                                                    "type": "boolean",
+                                                    "description": "Specifies whether a cookie is essential for the application to function correctly. If true then consent policy checks may be bypassed."
+                                                }
+                                            },
+                                            "additionalProperties": false
+                                        }
+                                    },
+                                    "additionalProperties": false
+                                },
+                                "HealthCheck": {
+                                    "type": "object",
+                                    "description": "Health check configuration for destinations.",
+                                    "properties": {
+                                        "Active": {
+                                            "type": "object",
+                                            "description": "Active health checks are based on sending health probing requests.",
+                                            "properties": {
+                                                "Enabled": {
+                                                    "type": "string",
+                                                    "description": "Determines if active health checks are enabled. Default false."
+                                                },
+                                                "Interval": {
+                                                    "type": "string",
+                                                    "description": "Period of sending health probing requests. Default 00:00:15"
+                                                },
+                                                "Timeout": {
+                                                    "type": "string",
+                                                    "description": "Period of waiting for a health check response. Default 00:00:10"
+                                                },
+                                                "Policy": {
+                                                    "type": "string",
+                                                    "description": "Determines the health check policy.",
+                                                    "enum": [
+                                                        "ConsecutiveFailures"
+                                                    ]
+                                                },
+                                                "Path": {
+                                                    "type": "string",
+                                                    "description": "Path to send health check requests to. Default /"
+                                                },
+                                                "Query": {
+                                                    "type": "string",
+                                                    "description": "Query string to send with health check requests."
+                                                }
+                                            },
+                                            "additionalProperties": false
+                                        },
+                                        "Passive": {
+                                            "type": "object",
+                                            "description": "Passive health checks are based on observing the health of the responses from the destination.",
+                                            "properties": {
+                                                "Enabled": {
+                                                    "type": "boolean",
+                                                    "description": "Determines if passive health checks are enabled. Default false."
+                                                },
+                                                "Policy": {
+                                                    "type": "string",
+                                                    "description": "Determines the health check policy.",
+                                                    "enum": [
+                                                        "TransportFailureRate"
+                                                    ]
+                                                },
+                                                "ReactivationPeriod": {
+                                                    "type": "string",
+                                                    "description": "Period of waiting for reactivating a destination after a failure. Default 00:00:30"
+                                                }
+                                            },
+                                            "additionalProperties": false
+                                        }
+                                    },
+                                    "additionalProperties": false
+                                },
+                                "HttpClient": {
+                                    "type": "object",
+                                    "description": "Configuration for outbound HTTP connections.",
+                                    "properties": {
+                                        "SSLProtocols": {
+                                            "type": "array",
+                                            "description": "Specifies the SSL protocols to use.",
+                                            "items": {
+                                                "type": "string"
+                                            }
+                                        },
+                                        "DangerousAcceptAnyServerCertificate": {
+                                            "type": "boolean",
+                                            "description": "Determines whether the server's SSL certificate validity is checked by the client. Setting it to true completely disables validation. Default value is false."
+                                        },
+                                        "MaxConnectionsPerServer": {
+                                            "type": "number",
+                                            "description": "Specifies the maximum number of connections per server."
+                                        },
+                                        "EnableMultipleHttp2Connections": {
+                                            "type": "boolean",
+                                            "description": "Determines if multiple HTTP/2 connections are enabled."
+                                        },
+                                        "RequestHeaderEncoding": {
+                                            "type": "string",
+                                            "description": "Specifies the encoding of request headers, e.g. 'utf-8'"
+                                        },
+                                        "ResponseHeaderEncoding": {
+                                            "type": "string",
+                                            "description": "Specifies the encoding of response headers, e.g. 'utf-8'"
+                                        }
+                                    },
+                                    "additionalProperties": false
+                                },
+                                "HttpRequest": {
+                                    "type": "object",
+                                    "description": "Options controlling requests sent to destinations.",
+                                    "properties": {
+                                        "ActivityTimeout": {
+                                            "type": "string",
+                                            "description": "Specifies the activity timeout for the request."
+                                        },
+                                        "Version": {
+                                            "type": "string",
+                                            "description": "Specifies the HTTP version to use for the request, e.g. '2'"
+                                        },
+                                        "VersionPolicy": {
+                                            "type": "string",
+                                            "description": "Specifies the HTTP version policy to use for the request,",
+                                            "enum": [
+                                                "RequestVersionExact",
+                                                "RequestVersionOrLower",
+                                                "RequestVersionOrHigher",
+                                                "ResponseVersionExact",
+                                                "ResponseVersionOrLower",
+                                                "ResponseVersionOrHigher"
+                                            ]
+                                        },
+                                        "AllowResponseBuffering": {
+                                            "type": "boolean",
+                                            "description": "Determines if response buffering is allowed."
+                                        }
+                                    },
+                                    "additionalProperties": false
+                                },
+                                "Metadata": {
+                                    "type": "object",
+                                    "description": "Arbitrary key-value pairs for custom cluster logic.",
+                                    "additionalProperties": {
+                                        "type": "string"
+                                    }
+                                }
+                            },
+                            "additionalProperties": false
+                        }
+                    }
+                }
+            },
+            "additionalProperties": false
+        }
+    },
+    "required": [
+        "Urls",
+        "ReverseProxy"
+    ],
+    "additionalProperties": false
+}

--- a/src/ReverseProxy/ConfigurationSchema.json
+++ b/src/ReverseProxy/ConfigurationSchema.json
@@ -1122,7 +1122,7 @@
                   "type": [ "object", "null" ],
                   "description": "Configuration for outbound HTTP connections.",
                   "properties": {
-                    "SSLProtocols": {
+                    "SslProtocols": {
                       "type": "array",
                       "description": "Specifies the SSL protocols to use.",
                       "items": {

--- a/src/ReverseProxy/ConfigurationSchema.json
+++ b/src/ReverseProxy/ConfigurationSchema.json
@@ -56,7 +56,7 @@
                   "properties": {
                     "Path": {
                       "type": [ "string", "null" ],
-                      "description": "Path pattern using ASP.NET route template syntax, e.g. '/something/{**remainder}'"
+                      "description": "Path pattern using ASP.NET route template syntax, e.g. '/something/{**remainder}'."
                     },
                     "Hosts": {
                       "type": [ "array", "null" ],
@@ -418,7 +418,7 @@
                       },
                       {
                         "type": "object",
-                        "description": "Changes the http method used in the request",
+                        "description": "Changes the http method used in the request.",
                         "properties": {
                           "HttpMethodChange": {
                             "description": "The HTTP method to replace.",
@@ -587,7 +587,8 @@
                           },
                           "HeaderPrefix": {
                             "type": "string",
-                            "description": "The header name prefix, defaults to 'X-Forwarded-`"
+                            "description": "The header name prefix.",
+                            "default": "X-Forwarded-"
                           }
                         },
                         "additionalProperties": false,
@@ -1031,17 +1032,20 @@
                       "properties": {
                         "Enabled": {
                           "type": [ "boolean", "null" ],
-                          "description": "Determines if active health checks are enabled. Defaults to false."
+                          "description": "Determines if active health checks are enabled.",
+                          "default": false
                         },
                         "Interval": {
                           "type": [ "string", "null" ],
                           "pattern": "^-?\\d*?\\.?\\d\\d:\\d\\d:\\d\\d\\.?\\d{0,7}$",
-                          "description": "Period of sending health probing requests. Defaults to '00:00:15'."
+                          "description": "Period of sending health probing requests.",
+                          "default": "00:00:15"
                         },
                         "Timeout": {
                           "type": [ "string", "null" ],
                           "pattern": "^-?\\d*?\\.?\\d\\d:\\d\\d:\\d\\d\\.?\\d{0,7}$",
-                          "description": "Period of waiting for a health check response. Defaults to '00:00:10'."
+                          "description": "Period of waiting for a health check response.",
+                          "default": "00:00:10"
                         },
                         "Policy": {
                           "anyOf": [
@@ -1059,7 +1063,8 @@
                         },
                         "Path": {
                           "type": [ "string", "null" ],
-                          "description": "HTTP health check endpoint path. Defaults to '/'."
+                          "description": "HTTP health check endpoint path.",
+                          "default": "/"
                         },
                         "Query": {
                           "type": [ "string", "null" ],
@@ -1073,7 +1078,8 @@
                       "properties": {
                         "Enabled": {
                           "type": [ "boolean", "null" ],
-                          "description": "Determines if passive health checks are enabled. Default false."
+                          "description": "Determines if passive health checks are enabled.",
+                          "default": false
                         },
                         "Policy": {
                           "anyOf": [
@@ -1125,7 +1131,8 @@
                     },
                     "DangerousAcceptAnyServerCertificate": {
                       "type": [ "boolean", "null" ],
-                      "description": "Determines whether the server's SSL certificate validity is checked by the client. Setting it to true completely disables validation. Default value is false."
+                      "description": "Determines whether the server's SSL certificate validity is checked by the client. Setting it to true completely disables validation.",
+                      "default": false
                     },
                     "MaxConnectionsPerServer": {
                       "type": [ "number", "null" ],
@@ -1133,7 +1140,8 @@
                     },
                     "EnableMultipleHttp2Connections": {
                       "type": [ "boolean", "null" ],
-                      "description": "Determines if multiple HTTP/2 connections are enabled. Defaults to true."
+                      "description": "Determines if multiple HTTP/2 connections are enabled.",
+                      "default": true
                     },
                     "RequestHeaderEncoding": {
                       "type": [ "string", "null" ],
@@ -1154,11 +1162,13 @@
                         },
                         "BypassOnLocal": {
                           "type": [ "boolean", "null" ],
-                          "description": "If true, bypasses the proxy for local addresses. Defaults to false."
+                          "description": "If true, bypasses the proxy for local addresses.",
+                          "default": false
                         },
                         "UseDefaultCredentials": {
                           "type": [ "boolean", "null" ],
-                          "description": "If true, sends CredentialCache.DefaultCredentials with requests. Defaults to false."
+                          "description": "If true, sends CredentialCache.DefaultCredentials with requests.",
+                          "default": false
                         }
                       }
                     }
@@ -1171,15 +1181,18 @@
                     "ActivityTimeout": {
                       "type": [ "string", "null" ],
                       "pattern": "^-?\\d*?\\.?\\d\\d:\\d\\d:\\d\\d\\.?\\d{0,7}$",
-                      "description": "Specifies how long a request is allowed to remain idle between any operation completing, after which it will be canceled. Default is 100 seconds."
+                      "description": "Specifies how long a request is allowed to remain idle between any operation completing, after which it will be canceled.",
+                      "default": "00:01:40"
                     },
                     "Version": {
                       "type": [ "string", "null" ],
-                      "description": "Preferred version of the outgoing request. Defaults to HTTP/2."
+                      "description": "Preferred version of the outgoing request.",
+                      "default": "2.0"
                     },
                     "VersionPolicy": {
                       "type": [ "string", "null" ],
-                      "description": "The policy applied to version selection, e.g. whether to prefer downgrades, upgrades or request an exact version. The default is `RequestVersionOrLower`.",
+                      "description": "The policy applied to version selection, e.g. whether to prefer downgrades, upgrades or request an exact version.",
+                      "default": "RequestVersionOrLower",
                       "enum": [
                         "RequestVersionExact",
                         "RequestVersionOrLower",

--- a/src/ReverseProxy/ConfigurationSchema.json
+++ b/src/ReverseProxy/ConfigurationSchema.json
@@ -880,12 +880,10 @@
                       "properties": {
                         "Address": {
                           "type": "string",
-                          "format": "iri",
                           "description": "Destination address (must include scheme)."
                         },
                         "Health": {
                           "type": [ "string", "null" ],
-                          "format": "iri",
                           "description": "Optional override URL accepting active health check probes."
                         },
                         "Host": {
@@ -1157,7 +1155,6 @@
                       "properties": {
                         "Address": {
                           "type": [ "string", "null" ],
-                          "format": "iri",
                           "description": "The URI of the proxy server."
                         },
                         "BypassOnLocal": {

--- a/src/ReverseProxy/ConfigurationSchema.json
+++ b/src/ReverseProxy/ConfigurationSchema.json
@@ -442,25 +442,8 @@
                             ]
                           },
                           "Set": {
-                            "description": "The new HTTP method.",
-                            "anyOf": [
-                              {
-                                "type": "string",
-                                "enum": [
-                                  "DELETE",
-                                  "GET",
-                                  "HEAD",
-                                  "OPTIONS",
-                                  "PATCH",
-                                  "POST",
-                                  "PUT",
-                                  "TRACE"
-                                ]
-                              },
-                              {
-                                "type": "string"
-                              }
-                            ]
+                            "type": "string",
+                            "description": "The new HTTP method."
                           }
                         },
                         "additionalProperties": false,

--- a/src/ReverseProxy/ConfigurationSchema.json
+++ b/src/ReverseProxy/ConfigurationSchema.json
@@ -40,7 +40,7 @@
                 },
                 "Timeout": {
                   "type": [ "string", "null" ],
-                  "pattern": "^-?\\d*?\\.?\\d\\d:\\d\\d:\\d\\d\\.?\\d{0,7}$",
+                  "pattern": "^\\d*?\\.?\\d\\d:\\d\\d:\\d\\d\\.?\\d{0,7}$",
                   "description": "The Timeout to apply to this route. This overrides any system defaults. Setting both Timeout and TimeoutPolicy is an error. Format: 'hh:mm:ss'."
                 },
                 "TimeoutPolicy": {
@@ -978,12 +978,12 @@
                         },
                         "Expiration": {
                           "type": [ "string", "null" ],
-                          "pattern": "^-?\\d*?\\.?\\d\\d:\\d\\d:\\d\\d\\.?\\d{0,7}$",
+                          "pattern": "^\\d*?\\.?\\d\\d:\\d\\d:\\d\\d\\.?\\d{0,7}$",
                           "description": "Specifies the expiration of the cookie. Format: 'hh:mm:ss'."
                         },
                         "MaxAge": {
                           "type": [ "string", "null" ],
-                          "pattern": "^-?\\d*?\\.?\\d\\d:\\d\\d:\\d\\d\\.?\\d{0,7}$",
+                          "pattern": "^\\d*?\\.?\\d\\d:\\d\\d:\\d\\d\\.?\\d{0,7}$",
                           "description": "Specifies the maximum age of the cookie. Format: 'hh:mm:ss'."
                         },
                         "SecurePolicy": {
@@ -1037,13 +1037,13 @@
                         },
                         "Interval": {
                           "type": [ "string", "null" ],
-                          "pattern": "^-?\\d*?\\.?\\d\\d:\\d\\d:\\d\\d\\.?\\d{0,7}$",
+                          "pattern": "^\\d*?\\.?\\d\\d:\\d\\d:\\d\\d\\.?\\d{0,7}$",
                           "description": "Period of sending health probing requests. Format: 'hh:mm:ss'.",
                           "default": "00:00:15"
                         },
                         "Timeout": {
                           "type": [ "string", "null" ],
-                          "pattern": "^-?\\d*?\\.?\\d\\d:\\d\\d:\\d\\d\\.?\\d{0,7}$",
+                          "pattern": "^\\d*?\\.?\\d\\d:\\d\\d:\\d\\d\\.?\\d{0,7}$",
                           "description": "Period of waiting for a health check response. Format: 'hh:mm:ss'.",
                           "default": "00:00:10"
                         },
@@ -1098,7 +1098,7 @@
                         },
                         "ReactivationPeriod": {
                           "type": [ "string", "null" ],
-                          "pattern": "^-?\\d*?\\.?\\d\\d:\\d\\d:\\d\\d\\.?\\d{0,7}$",
+                          "pattern": "^\\d*?\\.?\\d\\d:\\d\\d:\\d\\d\\.?\\d{0,7}$",
                           "description": "Period after which an unhealthy destination reverts back to an Unknown health state. Format: 'hh:mm:ss'."
                         }
                       },
@@ -1184,7 +1184,7 @@
                   "properties": {
                     "ActivityTimeout": {
                       "type": [ "string", "null" ],
-                      "pattern": "^-?\\d*?\\.?\\d\\d:\\d\\d:\\d\\d\\.?\\d{0,7}$",
+                      "pattern": "^\\d*?\\.?\\d\\d:\\d\\d:\\d\\d\\.?\\d{0,7}$",
                       "description": "Specifies how long a request is allowed to remain idle between any operation completing, after which it will be canceled. Format: 'hh:mm:ss'.",
                       "default": "00:01:40"
                     },

--- a/src/ReverseProxy/ConfigurationSchema.json
+++ b/src/ReverseProxy/ConfigurationSchema.json
@@ -11,7 +11,7 @@
           "type": "object",
           "description": "Named routes that direct incoming requests to clusters.",
           "patternProperties": {
-            "^[A-Za-z0-9_-]+$": {
+            ".": {
               "type": "object",
               "properties": {
                 "ClusterId": {
@@ -867,14 +867,14 @@
           "type": "object",
           "description": "Named clusters describing destinations.",
           "patternProperties": {
-            "^[A-Za-z0-9_-]+$": {
+            ".": {
               "type": "object",
               "properties": {
                 "Destinations": {
                   "type": "object",
                   "description": "Named destinations where traffic is forwarded.",
                   "patternProperties": {
-                    "^[A-Za-z0-9_-]+$": {
+                    ".": {
                       "type": "object",
                       "properties": {
                         "Address": {

--- a/src/ReverseProxy/ConfigurationSchema.json
+++ b/src/ReverseProxy/ConfigurationSchema.json
@@ -1,1006 +1,1215 @@
 {
-    "$id": "https://yarp.dot.net/reverseproxy/YarpConfigSchema.json",
-    "$schema": "http://json-schema.org/draft-07/schema#",
-    "title": "YARP Configuration Schema",
-    "description": "https://yarp.dot.net",
-    "type": "object",
-    "properties": {
-        "Urls": {
-            "type": "string",
-            "description": "One or more listening URLs separated by semicolons."
-        },
-        "Logging": {
-            "type": "object",
-            "description": "Logging configuration settings.",
-            "properties": {
-                "LogLevel": {
-                    "type": "object",
-                    "description": "Maps logging providers to log levels.",
-                    "additionalProperties": {
-                        "type": "string"
-                    }
-                }
-            },
-            "additionalProperties": true
-        },
-        "ReverseProxy": {
-            "type": "object",
-            "description": "Reverse proxy configuration for routes and clusters.",
-            "properties": {
-                "Routes": {
-                    "type": "object",
-                    "description": "Named routes that direct incoming requests to clusters.",
-                    "patternProperties": {
-                        "^[A-Za-z0-9_-]+$": {
-                            "type": "object",
-                            "properties": {
-                                "ClusterId": {
-                                    "type": "string",
-                                    "description": "Name of the cluster this route points to."
-                                },
-                                "Order": {
-                                    "type": "number",
-                                    "description": "Determines route priority; lower values match first."
-                                },
-                                "MaxRequestBodySize": {
-                                    "type": "number",
-                                    "description": "Optional override for max request body size in bytes."
-                                },
-                                "AuthorizationPolicy": {
-                                    "type": "string",
-                                    "description": "Specifies which authorization policy applies, e.g. 'Default' or 'Anonymous'."
-                                },
-                                "CorsPolicy": {
-                                    "type": "string",
-                                    "description": "Specifies which CORS policy applies, e.g. 'Default' or 'Disable'."
-                                },
-                                "Match": {
-                                    "type": "object",
-                                    "properties": {
-                                        "Path": {
-                                            "type": "string",
-                                            "description": "Path pattern using ASP.NET route template syntax, e.g. '/something/{**remainder}'"
-                                        },
-                                        "Hosts": {
-                                            "type": "array",
-                                            "description": "Host names to match, e.g. 'www.aaaa.com'",
-                                            "items": {
-                                                "type": "string"
-                                            }
-                                        },
-                                        "Methods": {
-                                            "type": "array",
-                                            "description": "Allowed HTTP methods, e.g. 'GET'",
-                                            "items": {
-                                                "type": "string"
-                                            }
-                                        },
-                                        "Headers": {
-                                            "type": "array",
-                                            "description": "List of header match conditions.",
-                                            "items": {
-                                                "type": "object",
-                                                "properties": {
-                                                    "Name": {
-                                                        "type": "string",
-                                                        "description": "Header name"
-                                                    },
-                                                    "Values": {
-                                                        "type": "array",
-                                                        "description": "Matches against any of these values",
-                                                        "items": {
-                                                            "type": "string"
-                                                        }
-                                                    },
-                                                    "Mode": {
-                                                        "type": "string",
-                                                        "description": "How the header values should be matched",
-                                                        "enum": [
-                                                            "ExactHeader",
-                                                            "HeaderPrefix",
-                                                            "Exists",
-                                                            "Contains",
-                                                            "NotContains",
-                                                            "NotExists"
-                                                        ]
-                                                    },
-                                                    "IsCaseSensitive": {
-                                                        "type": "boolean"
-                                                    }
-                                                },
-                                                "required": [
-                                                    "Name"
-                                                ]
-                                            }
-                                        },
-                                        "QueryParameters": {
-                                            "type": "array",
-                                            "description": "List of query string match conditions.",
-                                            "items": {
-                                                "type": "object",
-                                                "properties": {
-                                                    "Name": {
-                                                        "type": "string",
-                                                        "description": "Name of the query parameter"
-                                                    },
-                                                    "Values": {
-                                                        "type": "array",
-                                                        "description": "Matches are against any of the specified values",
-                                                        "items": {
-                                                            "type": "string"
-                                                        }
-                                                    },
-                                                    "Mode": {
-                                                        "type": "string",
-                                                        "enum": [
-                                                            "Exact",
-                                                            "Prefix",
-                                                            "Exists",
-                                                            "Contains",
-                                                            "NotContains"
-                                                        ]
-                                                    },
-                                                    "IsCaseSensitive": {
-                                                        "type": "boolean"
-                                                    }
-                                                },
-                                                "required": [
-                                                    "Name"
-                                                ]
-                                            }
-                                        }
-                                    },
-                                    "additionalProperties": false
-                                },
-                                "Metadata": {
-                                    "type": "object",
-                                    "description": "Arbitrary key-value pairs for custom route logic.",
-                                    "additionalProperties": {
-                                        "type": "string"
-                                    }
-                                },
-                                "Transforms": {
-                                    "type": "array",
-                                    "description": "List of transform objects for request customization.",
-                                    "items": {
-                                        "description": "A single transform definition.",
-                                        "anyOf": [
-                                            {
-                                                "type": "object",
-                                                "description": "Transform controlling whether request headers are copied from the original request.",
-                                                "properties": {
-                                                    "RequestHeadersCopy": {
-                                                        "type": "boolean",
-                                                        "description": "If true, copies all request headers to outbound request."
-                                                    }
-                                                },
-                                                "additionalProperties": false,
-                                                "required": [
-                                                    "RequestHeadersCopy"
-                                                ]
-                                            },
-                                            {
-                                                "type": "object",
-                                                "description": "Transform to control whether the original host header is preserved.",
-                                                "properties": {
-                                                    "RequestHeaderOriginalHost": {
-                                                        "type": "boolean",
-                                                        "description": "If true, preserve the original Host header; otherwise the destination's host is used."
-                                                    }
-                                                },
-                                                "additionalProperties": false,
-                                                "required": [
-                                                    "RequestHeaderOriginalHost"
-                                                ]
-                                            },
-                                            {
-                                                "type": "object",
-                                                "description": "Transform for setting, appending, or removing a request header.",
-                                                "properties": {
-                                                    "RequestHeader": {
-                                                        "type": "string",
-                                                        "description": "The header name to operate on."
-                                                    },
-                                                    "Set": {
-                                                        "type": "string",
-                                                        "description": "Value to set in the given request header."
-                                                    },
-                                                    "Append": {
-                                                        "type": "string",
-                                                        "description": "Value to append to the given request header."
-                                                    },
-                                                    "Remove": {
-                                                        "type": "boolean",
-                                                        "description": "Removes the header if true."
-                                                    }
-                                                },
-                                                "additionalProperties": false,
-                                                "required": [
-                                                    "RequestHeader"
-                                                ]
-                                            },
-                                            {
-                                                "type": "object",
-                                                "description": "Transform that removes a specified prefix from the request path.",
-                                                "properties": {
-                                                    "PathRemovePrefix": {
-                                                        "type": "string",
-                                                        "description": "Prefix to remove from the existing request path."
-                                                    }
-                                                },
-                                                "additionalProperties": false,
-                                                "required": [
-                                                    "PathRemovePrefix"
-                                                ]
-                                            },
-                                            {
-                                                "type": "object",
-                                                "description": "Transform that replaces the entire request path with the provided value.",
-                                                "properties": {
-                                                    "PathSet": {
-                                                        "type": "string",
-                                                        "description": "Sets the request path to this value."
-                                                    }
-                                                },
-                                                "additionalProperties": false,
-                                                "required": [
-                                                    "PathSet"
-                                                ]
-                                            },
-                                            {
-                                                "type": "object",
-                                                "description": "Transform that adds or modifies path prefix.",
-                                                "properties": {
-                                                    "PathPrefix": {
-                                                        "type": "string",
-                                                        "description": "Path prefix to add if not already present."
-                                                    }
-                                                },
-                                                "additionalProperties": false,
-                                                "required": [
-                                                    "PathPrefix"
-                                                ]
-                                            },
-                                            {
-                                                "type": "object",
-                                                "description": "Transform that copies a parameter from the route and adds it as a query parameter.",
-                                                "properties": {
-                                                    "QueryParameterFromRoute": {
-                                                        "type": "string",
-                                                        "description": "Specifies the query parameter name to add or replace."
-                                                    },
-                                                    "RouteParameter": {
-                                                        "type": "string",
-                                                        "description": "Name of the route parameter to copy from."
-                                                    }
-                                                },
-                                                "additionalProperties": false,
-                                                "required": [
-                                                    "QueryParameterFromRoute",
-                                                    "RouteParameter"
-                                                ]
-                                            },
-                                            {
-                                                "type": "object",
-                                                "description": "Transform that replaces the entire request path using a pattern template, replacing {} segments with the route value",
-                                                "properties": {
-                                                    "PathPattern": {
-                                                        "type": "string",
-                                                        "description": "A path template starting with a '/'"
-                                                    }
-                                                },
-                                                "additionalProperties": false,
-                                                "required": [
-                                                    "PathPattern"
-                                                ]
-                                            },
-                                            {
-                                                "type": "object",
-                                                "description": "Adds or replaces parameters in the request query string",
-                                                "properties": {
-                                                    "QueryValueParameter": {
-                                                        "type": "string",
-                                                        "description": "Name of a query string parameter"
-                                                    },
-                                                    "Set": {
-                                                        "type": "string",
-                                                        "description": "Value to set in the given query parameter."
-                                                    },
-                                                    "Append": {
-                                                        "type": "string",
-                                                        "description": "Value to append to the given query parameter."
-                                                    }
-                                                },
-                                                "additionalProperties": false,
-                                                "required": [
-                                                    "QueryValueParameter"
-                                                ]
-                                            },
-                                            {
-                                                "type": "object",
-                                                "description": "Adds or replaces a query string parameter with a value from the route configuration",
-                                                "properties": {
-                                                    "QueryRouteParameter": {
-                                                        "type": "string",
-                                                        "description": "Name of a query string parameter"
-                                                    },
-                                                    "Set": {
-                                                        "type": "string",
-                                                        "description": "Route value to set in the given query parameter."
-                                                    },
-                                                    "Append": {
-                                                        "type": "string",
-                                                        "description": "Route value to append to the given query parameter."
-                                                    }
-                                                },
-                                                "additionalProperties": false,
-                                                "required": [
-                                                    "QueryRouteParameter"
-                                                ]
-                                            },
-                                            {
-                                                "type": "object",
-                                                "description": "Removes the specified parameter from the request query string",
-                                                "properties": {
-                                                    "QueryRemoveParameter": {
-                                                        "type": "string",
-                                                        "description": "Name of a query string parameter"
-                                                    }
-                                                },
-                                                "additionalProperties": false,
-                                                "required": [
-                                                    "QueryRemoveParameter"
-                                                ]
-                                            },
-                                            {
-                                                "type": "object",
-                                                "description": "Adds or replaces parameters in the request query string",
-                                                "properties": {
-                                                    "HttpMethodChange": {
-                                                        "type": "string",
-                                                        "description": "The http method to replace"
-                                                    },
-                                                    "Set": {
-                                                        "type": "string",
-                                                        "description": "The new HTTP method"
-                                                    }
-                                                },
-                                                "additionalProperties": false,
-                                                "required": [
-                                                    "HttpMethodChange"
-                                                ]
-                                            },
-                                            {
-                                                "type": "object",
-                                                "description": "Adds or replaces a header with a value from the route configuration",
-                                                "properties": {
-                                                    "RequestHeaderRouteValue": {
-                                                        "type": "string",
-                                                        "description": "Name of a query string parameter"
-                                                    },
-                                                    "Set": {
-                                                        "type": "string",
-                                                        "description": "Route value to set in the given header."
-                                                    },
-                                                    "Append": {
-                                                        "type": "string",
-                                                        "description": "Route value to append to the given header."
-                                                    }
-                                                },
-                                                "additionalProperties": false,
-                                                "required": [
-                                                    "RequestHeaderRouteValue"
-                                                ]
-                                            },
-                                            {
-                                                "type": "object",
-                                                "description": "Removes the specified header from the request",
-                                                "properties": {
-                                                    "RequestHeaderRemove": {
-                                                        "type": "string",
-                                                        "description": "The header name"
-                                                    }
-                                                },
-                                                "additionalProperties": false,
-                                                "required": [
-                                                    "RequestHeaderRemove"
-                                                ]
-                                            },
-                                            {
-                                                "type": "object",
-                                                "description": "YARP copies most request headers to the proxy request by default, this transform disables RequestHeadersCopy and only copies the given headers.",
-                                                "properties": {
-                                                    "RequestHeadersAllowed": {
-                                                        "type": "string",
-                                                        "description": "A semicolon separated list of allowed header names."
-                                                    }
-                                                },
-                                                "additionalProperties": false,
-                                                "required": [
-                                                    "RequestHeadersAllowed"
-                                                ]
-                                            },
-                                            {
-                                                "type": "object",
-                                                "description": "Adds headers with information about the original client request",
-                                                "properties": {
-                                                    "X-Forwarded": {
-                                                        "type": "string",
-                                                        "description": "Default action to apply to all X-Forwarded-* headers",
-                                                        "enum": [
-                                                            "Set",
-                                                            "Append",
-                                                            "Remove",
-                                                            "Off"
-                                                        ]
-                                                    },
-                                                    "For": {
-                                                        "type": "string",
-                                                        "description": "Action to apply to the 'For' header",
-                                                        "enum": [
-                                                            "Set",
-                                                            "Append",
-                                                            "Remove",
-                                                            "Off"
-                                                        ]
-                                                    },
-                                                    "Proto": {
-                                                        "type": "string",
-                                                        "description": "Action to apply to the 'Proto' header",
-                                                        "enum": [
-                                                            "Set",
-                                                            "Append",
-                                                            "Remove",
-                                                            "Off"
-                                                        ]
-                                                    },
-                                                    "Host": {
-                                                        "type": "string",
-                                                        "description": "Action to apply to the 'Host' header",
-                                                        "enum": [
-                                                            "Set",
-                                                            "Append",
-                                                            "Remove",
-                                                            "Off"
-                                                        ]
-                                                    },
-                                                    "Prefix": {
-                                                        "type": "string",
-                                                        "description": "Action to apply to the 'Prefix' header",
-                                                        "enum": [
-                                                            "Set",
-                                                            "Append",
-                                                            "Remove",
-                                                            "Off"
-                                                        ]
-                                                    },
-                                                    "HeaderPrefix": {
-                                                        "type": "string",
-                                                        "description": "The header name prefix, defaults to 'X-Forwarded-`"
-                                                    }
-                                                },
-                                                "additionalProperties": false,
-                                                "required": [
-                                                    "X-Forwarded"
-                                                ]
-                                            },
-                                            {
-                                                "type": "object",
-                                                "description": "Adds a header with information about the original client request",
-                                                "properties": {
-                                                    "Forwarded": {
-                                                        "type": "string",
-                                                        "description": "A comma separated list containing any of these values: 'for,by,proto,host'"
-                                                    },
-                                                    "ForFormat": {
-                                                        "type": "string",
-                                                        "description": "Format to apply to the 'For' header",
-                                                        "enum": [
-                                                            "Random",
-                                                            "RandomAndPort",
-                                                            "RandomAndRandomPort",
-                                                            "Unknown",
-                                                            "UnknownAndPort",
-                                                            "UnknownAndRandomPort",
-                                                            "Ip",
-                                                            "IpAndPort",
-                                                            "IpAndRandomPort"
-                                                        ]
-                                                    },
-                                                    "ByFormat": {
-                                                        "type": "string",
-                                                        "description": "Format to apply to the 'For' header",
-                                                        "enum": [
-                                                            "Random",
-                                                            "RandomAndPort",
-                                                            "RandomAndRandomPort",
-                                                            "Unknown",
-                                                            "UnknownAndPort",
-                                                            "UnknownAndRandomPort",
-                                                            "Ip",
-                                                            "IpAndPort",
-                                                            "IpAndRandomPort"
-                                                        ]
-                                                    },
-                                                    "Action": {
-                                                        "type": "string",
-                                                        "description": "Action to apply to an existing 'Forwarded' header",
-                                                        "enum": [
-                                                            "Set",
-                                                            "Append",
-                                                            "Remove",
-                                                            "Off"
-                                                        ]
-                                                    }
-                                                },
-                                                "additionalProperties": false,
-                                                "required": [
-                                                    "Forwarded"
-                                                ]
-                                            },
-                                            {
-                                                "type": "object",
-                                                "description": "Forwards the client cert used on the inbound connection as a header to destination",
-                                                "properties": {
-                                                    "ClientCert": {
-                                                        "type": "string",
-                                                        "description": "The header name to use for the forwarded client cert"
-                                                    }
-                                                },
-                                                "additionalProperties": false,
-                                                "required": [
-                                                    "ClientCert"
-                                                ]
-                                            },
-                                            {
-                                                "type": "object",
-                                                "description": "Transform controlling whether response headers are copied from the original response.",
-                                                "properties": {
-                                                    "ResponseHeadersCopy": {
-                                                        "type": "boolean",
-                                                        "description": "If true, copies all response headers to outbound response."
-                                                    }
-                                                },
-                                                "additionalProperties": false,
-                                                "required": [
-                                                    "ResponseHeadersCopy"
-                                                ]
-                                            },
-                                            {
-                                                "type": "object",
-                                                "description": "Transform for setting, appending, or removing a response header.",
-                                                "properties": {
-                                                    "ResponseHeader": {
-                                                        "type": "string",
-                                                        "description": "The header name to operate on."
-                                                    },
-                                                    "Set": {
-                                                        "type": "string",
-                                                        "description": "Value to set in the given response header."
-                                                    },
-                                                    "Append": {
-                                                        "type": "string",
-                                                        "description": "Value to append to the given response header."
-                                                    },
-                                                    "When": {
-                                                        "type": "string",
-                                                        "enum": [
-                                                            "Success",
-                                                            "Always",
-                                                            "Failure"
-                                                        ],
-                                                        "description": "Specifies if the response header should be included for all, successful, or failure responses. Any response with a status code less than 400 is considered a success."
-                                                    }
-                                                },
-                                                "additionalProperties": false,
-                                                "required": [
-                                                    "ResponseHeader"
-                                                ]
-                                            },
-                                            {
-                                                "type": "object",
-                                                "description": "Removes the specified header from the response",
-                                                "properties": {
-                                                    "ResponseHeaderRemove": {
-                                                        "type": "string",
-                                                        "description": "The header name"
-                                                    },
-                                                    "When": {
-                                                        "type": "string",
-                                                        "enum": [
-                                                            "Success",
-                                                            "Always",
-                                                            "Failure"
-                                                        ],
-                                                        "description": "Specifies if the response header should be included for all, successful, or failure responses. Any response with a status code less than 400 is considered a success."
-                                                    }
-                                                },
-                                                "additionalProperties": false,
-                                                "required": [
-                                                    "ResponseHeaderRemove"
-                                                ]
-                                            },
-                                            {
-                                                "type": "object",
-                                                "description": "YARP copies most response headers to the proxy response by default, this transform disables ResponseHeadersCopy and only copies the given headers.",
-                                                "properties": {
-                                                    "ResponseHeadersAllowed": {
-                                                        "type": "string",
-                                                        "description": "A semicolon separated list of allowed header names."
-                                                    }
-                                                },
-                                                "additionalProperties": false,
-                                                "required": [
-                                                    "ResponseHeadersAllowed"
-                                                ]
-                                            },
-                                            {
-                                                "type": "object",
-                                                "description": "Sets whether destination trailing response headers are copied to the client",
-                                                "properties": {
-                                                    "ResponseTrailersCopy": {
-                                                        "type": "boolean",
-                                                        "description": "If true, copies all response trailers to outbound response."
-                                                    }
-                                                },
-                                                "additionalProperties": false,
-                                                "required": [
-                                                    "ResponseTrailersCopy"
-                                                ]
-                                            },
-                                            {
-                                                "type": "object",
-                                                "description": "Transform for setting, appending, or removing a response trailer.",
-                                                "properties": {
-                                                    "ResponseTrailer": {
-                                                        "type": "string",
-                                                        "description": "The trailer name to operate on."
-                                                    },
-                                                    "Set": {
-                                                        "type": "string",
-                                                        "description": "Value to set in the given response trailer."
-                                                    },
-                                                    "Append": {
-                                                        "type": "string",
-                                                        "description": "Value to append to the given response trailer."
-                                                    },
-                                                    "When": {
-                                                        "type": "string",
-                                                        "enum": [
-                                                            "Success",
-                                                            "Always",
-                                                            "Failure"
-                                                        ],
-                                                        "description": "Specifies if the response trailer should be included for all, successful, or failure responses. Any response with a status code less than 400 is considered a success."
-                                                    }
-                                                },
-                                                "additionalProperties": false,
-                                                "required": [
-                                                    "ResponseTrailer"
-                                                ]
-                                            },
-                                            {
-                                                "type": "object",
-                                                "description": "Removes the specified trailer from the response",
-                                                "properties": {
-                                                    "ResponseTrailerRemove": {
-                                                        "type": "string",
-                                                        "description": "The trailer name"
-                                                    },
-                                                    "When": {
-                                                        "type": "string",
-                                                        "enum": [
-                                                            "Success",
-                                                            "Always",
-                                                            "Failure"
-                                                        ],
-                                                        "description": "Specifies if the response trailer should be removed for all, successful, or failure responses. Any response with a status code less than 400 is considered a success."
-                                                    }
-                                                },
-                                                "additionalProperties": false,
-                                                "required": [
-                                                    "ResponseTrailerRemove"
-                                                ]
-                                            },
-                                            {
-                                                "type": "object",
-                                                "description": "YARP copies most response trailers to the proxy response by default, this transform disables ResponseTrailersCopy and only copies the given headers.",
-                                                "properties": {
-                                                    "ResponseTrailersAllowed": {
-                                                        "type": "string",
-                                                        "description": "A semicolon separated list of allowed trailer names."
-                                                    }
-                                                },
-                                                "additionalProperties": false,
-                                                "required": [
-                                                    "ResponseTrailersAllowed"
-                                                ]
-                                            }
-                                        ]
-                                    }
-                                }
-                            },
-                            "required": [
-                                "ClusterId",
-                                "Match"
-                            ],
-                            "additionalProperties": false
-                        }
-                    }
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "YARP Configuration Schema",
+  "type": "object",
+  "properties": {
+    "ReverseProxy": {
+      "type": "object",
+      "description": "Reverse proxy configuration for routes and clusters.",
+      "properties": {
+        "Routes": {
+          "type": "object",
+          "description": "Named routes that direct incoming requests to clusters.",
+          "patternProperties": {
+            "^[A-Za-z0-9_-]+$": {
+              "type": "object",
+              "properties": {
+                "ClusterId": {
+                  "type": "string",
+                  "description": "Name of the cluster this route points to."
                 },
-                "Clusters": {
-                    "type": "object",
-                    "description": "Named clusters describing destinations and load-balancing.",
-                    "patternProperties": {
-                        "^[A-Za-z0-9_-]+$": {
-                            "type": "object",
-                            "properties": {
-                                "Destinations": {
-                                    "type": "object",
-                                    "description": "Named destinations where traffic is forwarded.",
-                                    "patternProperties": {
-                                        "^[A-Za-z0-9_-]+$": {
-                                            "type": "object",
-                                            "properties": {
-                                                "Address": {
-                                                    "type": "string",
-                                                    "description": "Destination address (must include scheme)."
-                                                },
-                                                "Health": {
-                                                    "type": "string",
-                                                    "description": "Optional override URL checked during active health."
-                                                }
-                                            },
-                                            "required": [
-                                                "Address"
-                                            ],
-                                            "additionalProperties": false
-                                        }
-                                    }
-                                },
-                                "LoadBalancingPolicy": {
-                                    "type": "string",
-                                    "enum": [
-                                        "PowerOfTwoChoices",
-                                        "FirstAlphabetical",
-                                        "Random",
-                                        "RoundRobin",
-                                        "LeastRequests"
-                                    ],
-                                    "description": "Determines traffic distribution among destinations."
-                                },
-                                "SessionAffinity": {
-                                    "type": "object",
-                                    "description": "Session affinity is a mechanism to bind (affinitize) a causally related request sequence to the destination that handled the first request when the load is balanced among several destinations.",
-                                    "properties": {
-                                        "Enabled": {
-                                            "type": "boolean"
-                                        },
-                                        "Policy": {
-                                            "type": "string",
-                                            "enum": [
-                                                "HashCookie",
-                                                "ArrCookie",
-                                                "Cookie",
-                                                "CustomHeader"
-                                            ],
-                                            "description": "Affinity failure policy to use if the affinity key cannot be decoded or no healthy destination found ."
-                                        },
-                                        "FailurePolicy": {
-                                            "type": "string",
-                                            "enum": [
-                                                "Redistribute",
-                                                "Return503Error"
-                                            ],
-                                            "description": "Determines how the session will be stored and retrieved."
-                                        },
-                                        "AffinityKeyName": {
-                                            "type": "string",
-                                            "description": "Affinity key used to identify the target destination."
-                                        },
-                                        "Cookie": {
-                                            "type": "object",
-                                            "properties": {
-                                                "Name": {
-                                                    "type": "string",
-                                                    "description": "Specifies the name of the cookie."
-                                                },
-                                                "Domain": {
-                                                    "type": "string",
-                                                    "description": "Specifies the domain of the cookie."
-                                                },
-                                                "Path": {
-                                                    "type": "string",
-                                                    "description": "Specifies the path of the cookie."
-                                                },
-                                                "Expiration": {
-                                                    "type": "string",
-                                                    "description": "Specifies the expiration of the cookie."
-                                                },
-                                                "MaxAge": {
-                                                    "type": "string",
-                                                    "description": "Specifies the maximum age of the cookie."
-                                                },
-                                                "SecurePolicy": {
-                                                    "type": "string",
-                                                    "enum": [
-                                                        "Always",
-                                                        "None",
-                                                        "SameAsRequest"
-                                                    ],
-                                                    "description": "Specifies the Secure attribute of the cookie."
-                                                },
-                                                "HttpOnly": {
-                                                    "type": "boolean",
-                                                    "description": "Specifies whether a cookie is accessible by client-side script."
-                                                },
-                                                "SameSite": {
-                                                    "type": "string",
-                                                    "enum": [
-                                                        "Lax",
-                                                        "None",
-                                                        "Strict",
-                                                        "Unspecified"
-                                                    ],
-                                                    "description": "Specifies the SameSite attribute of the cookie."
-                                                },
-                                                "IsEssential": {
-                                                    "type": "boolean",
-                                                    "description": "Specifies whether a cookie is essential for the application to function correctly. If true then consent policy checks may be bypassed."
-                                                }
-                                            },
-                                            "additionalProperties": false
-                                        }
-                                    },
-                                    "additionalProperties": false
-                                },
-                                "HealthCheck": {
-                                    "type": "object",
-                                    "description": "Health check configuration for destinations.",
-                                    "properties": {
-                                        "Active": {
-                                            "type": "object",
-                                            "description": "Active health checks are based on sending health probing requests.",
-                                            "properties": {
-                                                "Enabled": {
-                                                    "type": "string",
-                                                    "description": "Determines if active health checks are enabled. Default false."
-                                                },
-                                                "Interval": {
-                                                    "type": "string",
-                                                    "description": "Period of sending health probing requests. Default 00:00:15"
-                                                },
-                                                "Timeout": {
-                                                    "type": "string",
-                                                    "description": "Period of waiting for a health check response. Default 00:00:10"
-                                                },
-                                                "Policy": {
-                                                    "type": "string",
-                                                    "description": "Determines the health check policy.",
-                                                    "enum": [
-                                                        "ConsecutiveFailures"
-                                                    ]
-                                                },
-                                                "Path": {
-                                                    "type": "string",
-                                                    "description": "Path to send health check requests to. Default /"
-                                                },
-                                                "Query": {
-                                                    "type": "string",
-                                                    "description": "Query string to send with health check requests."
-                                                }
-                                            },
-                                            "additionalProperties": false
-                                        },
-                                        "Passive": {
-                                            "type": "object",
-                                            "description": "Passive health checks are based on observing the health of the responses from the destination.",
-                                            "properties": {
-                                                "Enabled": {
-                                                    "type": "boolean",
-                                                    "description": "Determines if passive health checks are enabled. Default false."
-                                                },
-                                                "Policy": {
-                                                    "type": "string",
-                                                    "description": "Determines the health check policy.",
-                                                    "enum": [
-                                                        "TransportFailureRate"
-                                                    ]
-                                                },
-                                                "ReactivationPeriod": {
-                                                    "type": "string",
-                                                    "description": "Period of waiting for reactivating a destination after a failure. Default 00:00:30"
-                                                }
-                                            },
-                                            "additionalProperties": false
-                                        }
-                                    },
-                                    "additionalProperties": false
-                                },
-                                "HttpClient": {
-                                    "type": "object",
-                                    "description": "Configuration for outbound HTTP connections.",
-                                    "properties": {
-                                        "SSLProtocols": {
-                                            "type": "array",
-                                            "description": "Specifies the SSL protocols to use.",
-                                            "items": {
-                                                "type": "string"
-                                            }
-                                        },
-                                        "DangerousAcceptAnyServerCertificate": {
-                                            "type": "boolean",
-                                            "description": "Determines whether the server's SSL certificate validity is checked by the client. Setting it to true completely disables validation. Default value is false."
-                                        },
-                                        "MaxConnectionsPerServer": {
-                                            "type": "number",
-                                            "description": "Specifies the maximum number of connections per server."
-                                        },
-                                        "EnableMultipleHttp2Connections": {
-                                            "type": "boolean",
-                                            "description": "Determines if multiple HTTP/2 connections are enabled."
-                                        },
-                                        "RequestHeaderEncoding": {
-                                            "type": "string",
-                                            "description": "Specifies the encoding of request headers, e.g. 'utf-8'"
-                                        },
-                                        "ResponseHeaderEncoding": {
-                                            "type": "string",
-                                            "description": "Specifies the encoding of response headers, e.g. 'utf-8'"
-                                        }
-                                    },
-                                    "additionalProperties": false
-                                },
-                                "HttpRequest": {
-                                    "type": "object",
-                                    "description": "Options controlling requests sent to destinations.",
-                                    "properties": {
-                                        "ActivityTimeout": {
-                                            "type": "string",
-                                            "description": "Specifies the activity timeout for the request."
-                                        },
-                                        "Version": {
-                                            "type": "string",
-                                            "description": "Specifies the HTTP version to use for the request, e.g. '2'"
-                                        },
-                                        "VersionPolicy": {
-                                            "type": "string",
-                                            "description": "Specifies the HTTP version policy to use for the request,",
-                                            "enum": [
-                                                "RequestVersionExact",
-                                                "RequestVersionOrLower",
-                                                "RequestVersionOrHigher",
-                                                "ResponseVersionExact",
-                                                "ResponseVersionOrLower",
-                                                "ResponseVersionOrHigher"
-                                            ]
-                                        },
-                                        "AllowResponseBuffering": {
-                                            "type": "boolean",
-                                            "description": "Determines if response buffering is allowed."
-                                        }
-                                    },
-                                    "additionalProperties": false
-                                },
-                                "Metadata": {
-                                    "type": "object",
-                                    "description": "Arbitrary key-value pairs for custom cluster logic.",
-                                    "additionalProperties": {
-                                        "type": "string"
-                                    }
-                                }
-                            },
-                            "additionalProperties": false
-                        }
+                "Order": {
+                  "type": "number",
+                  "description": "Order value for this route. Routes with lower numbers take precedence over higher numbers."
+                },
+                "MaxRequestBodySize": {
+                  "type": "number",
+                  "description": "An optional override for how large request bodies can be in bytes."
+                },
+                "AuthorizationPolicy": {
+                  "type": "string",
+                  "description": "Specifies which authorization policy applies, e.g. 'Default' or 'Anonymous'."
+                },
+                "RateLimiterPolicy": {
+                  "type": "string",
+                  "description": "The name of the RateLimiterPolicy to apply to this route."
+                },
+                "OutputCachePolicy": {
+                  "type": "string",
+                  "description": "The name of the OutputCachePolicy to apply to this route."
+                },
+                "Timeout": {
+                  "type": "string",
+                  "pattern": "^-?\\d*?\\.?\\d\\d:\\d\\d:\\d\\d\\.?\\d{0,7}$",
+                  "description": "The Timeout to apply to this route. This overrides any system defaults. Setting both Timeout and TimeoutPolicy is an error."
+                },
+                "TimeoutPolicy": {
+                  "type": "string",
+                  "description": "Specifies which timeout policy applies, e.g. 'Default' or 'Disable'. Setting both Timeout and TimeoutPolicy is an error."
+                },
+                "CorsPolicy": {
+                  "type": "string",
+                  "description": "Specifies which CORS policy applies, e.g. 'Default' or 'Disable'."
+                },
+                "Match": {
+                  "type": "object",
+                  "properties": {
+                    "Path": {
+                      "type": "string",
+                      "description": "Path pattern using ASP.NET route template syntax, e.g. '/something/{**remainder}'"
+                    },
+                    "Hosts": {
+                      "type": "array",
+                      "description": "Only match requests with the given Host header. Supports wildcards and ports. For unicode host names, do not use punycode.",
+                      "items": {
+                        "type": "string"
+                      }
+                    },
+                    "Methods": {
+                      "type": "array",
+                      "description": "Allowed HTTP methods.",
+                      "items": {
+                        "anyOf": [
+                          {
+                            "type": "string",
+                            "enum": [
+                              "DELETE",
+                              "GET",
+                              "HEAD",
+                              "OPTIONS",
+                              "PATCH",
+                              "POST",
+                              "PUT",
+                              "TRACE"
+                            ]
+                          },
+                          {
+                            "type": "string"
+                          }
+                        ]
+                      }
+                    },
+                    "Headers": {
+                      "type": "array",
+                      "description": "List of header match conditions.",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "Name": {
+                            "type": "string",
+                            "description": "Header name."
+                          },
+                          "Values": {
+                            "type": "array",
+                            "description": "Matches against any of these values.",
+                            "items": {
+                              "type": "string"
+                            }
+                          },
+                          "Mode": {
+                            "type": "string",
+                            "description": "How the header values should be matched.",
+                            "enum": [
+                              "ExactHeader",
+                              "HeaderPrefix",
+                              "Contains",
+                              "NotContains",
+                              "Exists",
+                              "NotExists"
+                            ]
+                          },
+                          "IsCaseSensitive": {
+                            "type": "boolean"
+                          }
+                        },
+                        "required": [
+                          "Name"
+                        ]
+                      }
+                    },
+                    "QueryParameters": {
+                      "type": "array",
+                      "description": "List of query string match conditions.",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "Name": {
+                            "type": "string",
+                            "description": "Name of the query parameter."
+                          },
+                          "Values": {
+                            "type": "array",
+                            "description": "Matches against any of these values.",
+                            "items": {
+                              "type": "string"
+                            }
+                          },
+                          "Mode": {
+                            "type": "string",
+                            "description": "How the query parameter values should be matched.",
+                            "enum": [
+                              "Exact",
+                              "Contains",
+                              "NotContains",
+                              "Prefix",
+                              "Exists"
+                            ]
+                          },
+                          "IsCaseSensitive": {
+                            "type": "boolean"
+                          }
+                        },
+                        "required": [
+                          "Name"
+                        ]
+                      }
                     }
+                  }
+                },
+                "Metadata": {
+                  "type": "object",
+                  "description": "Arbitrary key-value pairs for custom route logic.",
+                  "additionalProperties": {
+                    "type": "string"
+                  }
+                },
+                "Transforms": {
+                  "type": "array",
+                  "description": "List of transform objects for request customization.",
+                  "items": {
+                    "description": "A single transform definition.",
+                    "anyOf": [
+                      {
+                        "type": "object",
+                        "$comment": "Fallback that matches any custom user-defined transforms.",
+                        "properties": {
+                          "RequestHeadersCopy": false,
+                          "RequestHeaderOriginalHost": false,
+                          "RequestHeader": false,
+                          "PathRemovePrefix": false,
+                          "PathSet": false,
+                          "PathPrefix": false,
+                          "QueryRouteParameter": false,
+                          "PathPattern": false,
+                          "QueryValueParameter": false,
+                          "QueryRemoveParameter": false,
+                          "HttpMethodChange": false,
+                          "RequestHeaderRouteValue": false,
+                          "RequestHeaderRemove": false,
+                          "RequestHeadersAllowed": false,
+                          "X-Forwarded": false,
+                          "Forwarded": false,
+                          "ClientCert": false,
+                          "ResponseHeadersCopy": false,
+                          "ResponseHeader": false,
+                          "ResponseHeaderRemove": false,
+                          "ResponseHeadersAllowed": false,
+                          "ResponseTrailersCopy": false,
+                          "ResponseTrailer": false,
+                          "ResponseTrailerRemove": false,
+                          "ResponseTrailersAllowed": false
+                        }
+                      },
+                      {
+                        "type": "object",
+                        "description": "Sets whether incoming request headers are copied to the outbound request.",
+                        "properties": {
+                          "RequestHeadersCopy": {
+                            "type": "boolean",
+                            "description": "If true, copies all request headers to outbound request."
+                          }
+                        },
+                        "additionalProperties": false,
+                        "required": [
+                          "RequestHeadersCopy"
+                        ]
+                      },
+                      {
+                        "type": "object",
+                        "description": "Specifies if the incoming request Host header should be copied to the proxy request.",
+                        "properties": {
+                          "RequestHeaderOriginalHost": {
+                            "type": "boolean",
+                            "description": "If true, preserve the original Host header; otherwise the destination's host is used."
+                          }
+                        },
+                        "additionalProperties": false,
+                        "required": [
+                          "RequestHeaderOriginalHost"
+                        ]
+                      },
+                      {
+                        "type": "object",
+                        "description": "Transform for setting, appending, or removing a request header.",
+                        "properties": {
+                          "RequestHeader": {
+                            "type": "string",
+                            "description": "The header name to operate on."
+                          },
+                          "Set": {
+                            "type": "string",
+                            "description": "Value to set the given request header to."
+                          },
+                          "Append": {
+                            "type": "string",
+                            "description": "Value to append to the given request header."
+                          },
+                          "Remove": {
+                            "type": "boolean",
+                            "description": "Removes the header if true."
+                          }
+                        },
+                        "additionalProperties": false,
+                        "anyOf": [
+                          {
+                            "required": [
+                              "RequestHeader",
+                              "Set"
+                            ]
+                          },
+                          {
+                            "required": [
+                              "RequestHeader",
+                              "Append"
+                            ]
+                          },
+                          {
+                            "required": [
+                              "RequestHeader",
+                              "Remove"
+                            ]
+                          }
+                        ]
+                      },
+                      {
+                        "type": "object",
+                        "description": "Transform that removes a specified prefix from the request path.",
+                        "properties": {
+                          "PathRemovePrefix": {
+                            "type": "string",
+                            "description": "Prefix to remove from the existing request path."
+                          }
+                        },
+                        "additionalProperties": false,
+                        "required": [
+                          "PathRemovePrefix"
+                        ]
+                      },
+                      {
+                        "type": "object",
+                        "description": "Transform that replaces the entire request path with the provided value.",
+                        "properties": {
+                          "PathSet": {
+                            "type": "string",
+                            "description": "Sets the request path to this value."
+                          }
+                        },
+                        "additionalProperties": false,
+                        "required": [
+                          "PathSet"
+                        ]
+                      },
+                      {
+                        "type": "object",
+                        "description": "Transform that adds the specified prefix to the request path.",
+                        "properties": {
+                          "PathPrefix": {
+                            "type": "string",
+                            "description": "Path prefix to add."
+                          }
+                        },
+                        "additionalProperties": false,
+                        "required": [
+                          "PathPrefix"
+                        ]
+                      },
+                      {
+                        "type": "object",
+                        "description": "Transform that adds or replaces a query string parameter with a value from the route configuration.",
+                        "properties": {
+                          "QueryRouteParameter": {
+                            "type": "string",
+                            "description": "Specifies the query parameter name to add or replace."
+                          },
+                          "Set": {
+                            "type": "string",
+                            "description": "Name of the route paramter to set the query parameter to."
+                          },
+                          "Append": {
+                            "type": "string",
+                            "description": "Name of the route paramter to append to the query parameter."
+                          }
+                        },
+                        "additionalProperties": false,
+                        "anyOf": [
+                          {
+                            "required": [
+                              "QueryRouteParameter",
+                              "Set"
+                            ]
+                          },
+                          {
+                            "required": [
+                              "QueryRouteParameter",
+                              "Append"
+                            ]
+                          }
+                        ]
+                      },
+                      {
+                        "type": "object",
+                        "description": "Transform that replaces the entire request path using a pattern template, replacing {} segments with the route value.",
+                        "properties": {
+                          "PathPattern": {
+                            "type": "string",
+                            "description": "A path template starting with a '/', e.g. '/my/{plugin}/api/{**remainder}'."
+                          }
+                        },
+                        "additionalProperties": false,
+                        "required": [
+                          "PathPattern"
+                        ]
+                      },
+                      {
+                        "type": "object",
+                        "description": "Adds or replaces parameters in the request query string.",
+                        "properties": {
+                          "QueryValueParameter": {
+                            "type": "string",
+                            "description": "Name of a query string parameter."
+                          },
+                          "Set": {
+                            "type": "string",
+                            "description": "Value to set the given query parameter to."
+                          },
+                          "Append": {
+                            "type": "string",
+                            "description": "Value to append to the given query parameter."
+                          }
+                        },
+                        "additionalProperties": false,
+                        "anyOf": [
+                          {
+                            "required": [
+                              "QueryValueParameter",
+                              "Set"
+                            ]
+                          },
+                          {
+                            "required": [
+                              "QueryValueParameter",
+                              "Append"
+                            ]
+                          }
+                        ]
+                      },
+                      {
+                        "type": "object",
+                        "description": "Removes the specified parameter from the request query string.",
+                        "properties": {
+                          "QueryRemoveParameter": {
+                            "type": "string",
+                            "description": "Name of a query string parameter."
+                          }
+                        },
+                        "additionalProperties": false,
+                        "required": [
+                          "QueryRemoveParameter"
+                        ]
+                      },
+                      {
+                        "type": "object",
+                        "description": "Changes the http method used in the request",
+                        "properties": {
+                          "HttpMethodChange": {
+                            "description": "The HTTP method to replace.",
+                            "anyOf": [
+                              {
+                                "type": "string",
+                                "enum": [
+                                  "DELETE",
+                                  "GET",
+                                  "HEAD",
+                                  "OPTIONS",
+                                  "PATCH",
+                                  "POST",
+                                  "PUT",
+                                  "TRACE"
+                                ]
+                              },
+                              {
+                                "type": "string"
+                              }
+                            ]
+                          },
+                          "Set": {
+                            "description": "The new HTTP method.",
+                            "anyOf": [
+                              {
+                                "type": "string",
+                                "enum": [
+                                  "DELETE",
+                                  "GET",
+                                  "HEAD",
+                                  "OPTIONS",
+                                  "PATCH",
+                                  "POST",
+                                  "PUT",
+                                  "TRACE"
+                                ]
+                              },
+                              {
+                                "type": "string"
+                              }
+                            ]
+                          }
+                        },
+                        "additionalProperties": false,
+                        "required": [
+                          "HttpMethodChange",
+                          "Set"
+                        ]
+                      },
+                      {
+                        "type": "object",
+                        "description": "Adds or replaces a header with a value from the route configuration.",
+                        "properties": {
+                          "RequestHeaderRouteValue": {
+                            "type": "string",
+                            "description": "The header name to operate on."
+                          },
+                          "Set": {
+                            "type": "string",
+                            "description": "Route value to set the given header to."
+                          },
+                          "Append": {
+                            "type": "string",
+                            "description": "Route value to append to the given header."
+                          }
+                        },
+                        "additionalProperties": false,
+                        "anyOf": [
+                          {
+                            "required": [
+                              "RequestHeaderRouteValue",
+                              "Set"
+                            ]
+                          },
+                          {
+                            "required": [
+                              "RequestHeaderRouteValue",
+                              "Append"
+                            ]
+                          }
+                        ]
+                      },
+                      {
+                        "type": "object",
+                        "description": "Removes the specified header from the request.",
+                        "properties": {
+                          "RequestHeaderRemove": {
+                            "type": "string",
+                            "description": "The header name."
+                          }
+                        },
+                        "additionalProperties": false,
+                        "required": [
+                          "RequestHeaderRemove"
+                        ]
+                      },
+                      {
+                        "type": "object",
+                        "description": "YARP copies most request headers to the proxy request by default, this transform disables RequestHeadersCopy and only copies the given headers.",
+                        "properties": {
+                          "RequestHeadersAllowed": {
+                            "type": "string",
+                            "pattern": "^[a-zA-Z0-9!#$%&'*+-.^_`|~;]+$",
+                            "description": "A semicolon separated list of allowed header names."
+                          }
+                        },
+                        "additionalProperties": false,
+                        "required": [
+                          "RequestHeadersAllowed"
+                        ]
+                      },
+                      {
+                        "type": "object",
+                        "description": "Adds headers with information about the original client request.",
+                        "properties": {
+                          "X-Forwarded": {
+                            "type": "string",
+                            "description": "Default action to apply to all X-Forwarded-* headers.",
+                            "enum": [
+                              "Set",
+                              "Append",
+                              "Remove",
+                              "Off"
+                            ]
+                          },
+                          "For": {
+                            "type": "string",
+                            "description": "Action to apply to the 'For' header.",
+                            "enum": [
+                              "Set",
+                              "Append",
+                              "Remove",
+                              "Off"
+                            ]
+                          },
+                          "Proto": {
+                            "type": "string",
+                            "description": "Action to apply to the 'Proto' header.",
+                            "enum": [
+                              "Set",
+                              "Append",
+                              "Remove",
+                              "Off"
+                            ]
+                          },
+                          "Host": {
+                            "type": "string",
+                            "description": "Action to apply to the 'Host' header.",
+                            "enum": [
+                              "Set",
+                              "Append",
+                              "Remove",
+                              "Off"
+                            ]
+                          },
+                          "Prefix": {
+                            "type": "string",
+                            "description": "Action to apply to the 'Prefix' header.",
+                            "enum": [
+                              "Set",
+                              "Append",
+                              "Remove",
+                              "Off"
+                            ]
+                          },
+                          "HeaderPrefix": {
+                            "type": "string",
+                            "description": "The header name prefix, defaults to 'X-Forwarded-`"
+                          }
+                        },
+                        "additionalProperties": false,
+                        "required": [
+                          "X-Forwarded"
+                        ]
+                      },
+                      {
+                        "type": "object",
+                        "description": "Adds a header with information about the original client request.",
+                        "properties": {
+                          "Forwarded": {
+                            "type": "string",
+                            "pattern": "^(?:(?:for|by|proto|host),?)+$",
+                            "description": "A comma separated list containing any of these values: 'for,by,proto,host'."
+                          },
+                          "ForFormat": {
+                            "type": "string",
+                            "description": "Format to apply to the 'For' header.",
+                            "enum": [
+                              "Random",
+                              "RandomAndPort",
+                              "RandomAndRandomPort",
+                              "Unknown",
+                              "UnknownAndPort",
+                              "UnknownAndRandomPort",
+                              "Ip",
+                              "IpAndPort",
+                              "IpAndRandomPort"
+                            ]
+                          },
+                          "ByFormat": {
+                            "type": "string",
+                            "description": "Format to apply to the 'For' header.",
+                            "enum": [
+                              "Random",
+                              "RandomAndPort",
+                              "RandomAndRandomPort",
+                              "Unknown",
+                              "UnknownAndPort",
+                              "UnknownAndRandomPort",
+                              "Ip",
+                              "IpAndPort",
+                              "IpAndRandomPort"
+                            ]
+                          },
+                          "Action": {
+                            "type": "string",
+                            "description": "Action to apply to the 'Forwarded' header.",
+                            "enum": [
+                              "Set",
+                              "Append",
+                              "Remove",
+                              "Off"
+                            ]
+                          }
+                        },
+                        "additionalProperties": false,
+                        "required": [
+                          "Forwarded"
+                        ]
+                      },
+                      {
+                        "type": "object",
+                        "description": "Forwards the client cert used on the inbound connection as a header to the destination.",
+                        "properties": {
+                          "ClientCert": {
+                            "type": "string",
+                            "description": "The header name to use for the forwarded client cert."
+                          }
+                        },
+                        "additionalProperties": false,
+                        "required": [
+                          "ClientCert"
+                        ]
+                      },
+                      {
+                        "type": "object",
+                        "description": "Transform controlling whether response headers are copied from the original response.",
+                        "properties": {
+                          "ResponseHeadersCopy": {
+                            "type": "boolean",
+                            "description": "If true, copies all response headers from the destination back to the client."
+                          }
+                        },
+                        "additionalProperties": false,
+                        "required": [
+                          "ResponseHeadersCopy"
+                        ]
+                      },
+                      {
+                        "type": "object",
+                        "description": "Transform for setting, appending, or removing a response header.",
+                        "properties": {
+                          "ResponseHeader": {
+                            "type": "string",
+                            "description": "The header name to operate on."
+                          },
+                          "Set": {
+                            "type": "string",
+                            "description": "Value to set the given response header to."
+                          },
+                          "Append": {
+                            "type": "string",
+                            "description": "Value to append to the given response header."
+                          },
+                          "When": {
+                            "type": "string",
+                            "enum": [
+                              "Success",
+                              "Always",
+                              "Failure"
+                            ],
+                            "description": "Specifies if the response header should be included for all, successful, or failure responses. Any response with a status code less than 400 is considered a success."
+                          }
+                        },
+                        "additionalProperties": false,
+                        "anyOf": [
+                          {
+                            "required": [
+                              "ResponseHeader",
+                              "Set"
+                            ]
+                          },
+                          {
+                            "required": [
+                              "ResponseHeader",
+                              "Append"
+                            ]
+                          }
+                        ]
+                      },
+                      {
+                        "type": "object",
+                        "description": "Removes the specified header from the response.",
+                        "properties": {
+                          "ResponseHeaderRemove": {
+                            "type": "string",
+                            "description": "The header name."
+                          },
+                          "When": {
+                            "type": "string",
+                            "enum": [
+                              "Success",
+                              "Always",
+                              "Failure"
+                            ],
+                            "description": "Specifies if the response header should be included for all, successful, or failure responses. Any response with a status code less than 400 is considered a success."
+                          }
+                        },
+                        "additionalProperties": false,
+                        "required": [
+                          "ResponseHeaderRemove"
+                        ]
+                      },
+                      {
+                        "type": "object",
+                        "description": "YARP copies most response headers to the proxy response by default, this transform disables ResponseHeadersCopy and only copies the given headers.",
+                        "properties": {
+                          "ResponseHeadersAllowed": {
+                            "type": "string",
+                            "pattern": "^[a-zA-Z0-9!#$%&'*+-.^_`|~;]+$",
+                            "description": "A semicolon separated list of allowed header names."
+                          }
+                        },
+                        "additionalProperties": false,
+                        "required": [
+                          "ResponseHeadersAllowed"
+                        ]
+                      },
+                      {
+                        "type": "object",
+                        "description": "Transform controlling whether trailing response headers are copied from the original response.",
+                        "properties": {
+                          "ResponseTrailersCopy": {
+                            "type": "boolean",
+                            "description": "If true, copies all trailing response headers from the destination back to the client."
+                          }
+                        },
+                        "additionalProperties": false,
+                        "required": [
+                          "ResponseTrailersCopy"
+                        ]
+                      },
+                      {
+                        "type": "object",
+                        "description": "Transform for setting, appending, or removing a response trailer.",
+                        "properties": {
+                          "ResponseTrailer": {
+                            "type": "string",
+                            "description": "The trailer name to operate on."
+                          },
+                          "Set": {
+                            "type": "string",
+                            "description": "Value to set the given response trailer to."
+                          },
+                          "Append": {
+                            "type": "string",
+                            "description": "Value to append to the given response trailer."
+                          },
+                          "When": {
+                            "type": "string",
+                            "enum": [
+                              "Success",
+                              "Always",
+                              "Failure"
+                            ],
+                            "description": "Specifies if the response trailer should be included for all, successful, or failure responses. Any response with a status code less than 400 is considered a success."
+                          }
+                        },
+                        "additionalProperties": false,
+                        "anyOf": [
+                          {
+                            "required": [
+                              "ResponseTrailer",
+                              "Set"
+                            ]
+                          },
+                          {
+                            "required": [
+                              "ResponseTrailer",
+                              "Append"
+                            ]
+                          }
+                        ]
+                      },
+                      {
+                        "type": "object",
+                        "description": "Removes the specified trailer from the response.",
+                        "properties": {
+                          "ResponseTrailerRemove": {
+                            "type": "string",
+                            "description": "The trailer name."
+                          },
+                          "When": {
+                            "type": "string",
+                            "enum": [
+                              "Success",
+                              "Always",
+                              "Failure"
+                            ],
+                            "description": "Specifies if the response trailer should be removed for all, successful, or failure responses. Any response with a status code less than 400 is considered a success."
+                          }
+                        },
+                        "additionalProperties": false,
+                        "required": [
+                          "ResponseTrailerRemove"
+                        ]
+                      },
+                      {
+                        "type": "object",
+                        "description": "YARP copies most response trailers to the proxy response by default, this transform disables ResponseTrailersCopy and only copies the given headers.",
+                        "properties": {
+                          "ResponseTrailersAllowed": {
+                            "type": "string",
+                            "pattern": "^[a-zA-Z0-9!#$%&'*+-.^_`|~;]+$",
+                            "description": "A semicolon separated list of allowed trailer names."
+                          }
+                        },
+                        "additionalProperties": false,
+                        "required": [
+                          "ResponseTrailersAllowed"
+                        ]
+                      }
+                    ]
+                  }
                 }
-            },
-            "additionalProperties": false
+              },
+              "required": [
+                "ClusterId",
+                "Match"
+              ]
+            }
+          }
+        },
+        "Clusters": {
+          "type": "object",
+          "description": "Named clusters describing destinations.",
+          "patternProperties": {
+            "^[A-Za-z0-9_-]+$": {
+              "type": "object",
+              "properties": {
+                "Destinations": {
+                  "type": "object",
+                  "description": "Named destinations where traffic is forwarded.",
+                  "patternProperties": {
+                    "^[A-Za-z0-9_-]+$": {
+                      "type": "object",
+                      "properties": {
+                        "Address": {
+                          "type": "string",
+                          "format": "iri",
+                          "description": "Destination address (must include scheme)."
+                        },
+                        "Health": {
+                          "type": "string",
+                          "format": "iri",
+                          "description": "Optional override URL accepting active health check probes."
+                        },
+                        "Host": {
+                          "type": "string",
+                          "description": "Optional fallback host header value used if a host is not already specified by request transforms."
+                        },
+                        "Metadata": {
+                          "type": "object",
+                          "description": "Arbitrary key-value pairs for custom destination logic.",
+                          "additionalProperties": {
+                            "type": "string"
+                          }
+                        }
+                      },
+                      "required": [
+                        "Address"
+                      ]
+                    }
+                  }
+                },
+                "LoadBalancingPolicy": {
+                  "anyOf": [
+                    {
+                      "type": "string",
+                      "enum": [
+                        "PowerOfTwoChoices",
+                        "FirstAlphabetical",
+                        "Random",
+                        "RoundRobin",
+                        "LeastRequests"
+                      ]
+                    },
+                    {
+                      "type": "string"
+                    }
+                  ],
+                  "description": "Determines traffic distribution among destinations."
+                },
+                "SessionAffinity": {
+                  "type": "object",
+                  "description": "Session affinity is a mechanism to bind (affinitize) a causally related request sequence to the destination that handled the first request when the load is balanced among several destinations.",
+                  "properties": {
+                    "Enabled": {
+                      "type": "boolean"
+                    },
+                    "Policy": {
+                      "anyOf": [
+                        {
+                          "type": "string",
+                          "enum": [
+                            "HashCookie",
+                            "ArrCookie",
+                            "Cookie",
+                            "CustomHeader"
+                          ]
+                        },
+                        {
+                          "type": "string"
+                        }
+                      ],
+                      "description": "Determines how the session will be stored and retrieved."
+                    },
+                    "FailurePolicy": {
+                      "anyOf": [
+                        {
+                          "type": "string",
+                          "enum": [
+                            "Redistribute",
+                            "Return503Error"
+                          ]
+                        },
+                        {
+                          "type": "string"
+                        }
+                      ],
+                      "description": "Strategy for handling a missing destination for an affinitized request."
+                    },
+                    "AffinityKeyName": {
+                      "type": "string",
+                      "description": "Identifies the name of the field where the affinity value is stored (cookie or header name)."
+                    },
+                    "Cookie": {
+                      "type": "object",
+                      "properties": {
+                        "Name": {
+                          "type": "string",
+                          "description": "Specifies the name of the cookie."
+                        },
+                        "Domain": {
+                          "type": "string",
+                          "description": "Specifies the domain of the cookie."
+                        },
+                        "Path": {
+                          "type": "string",
+                          "description": "Specifies the path of the cookie."
+                        },
+                        "Expiration": {
+                          "type": "string",
+                          "pattern": "^-?\\d*?\\.?\\d\\d:\\d\\d:\\d\\d\\.?\\d{0,7}$",
+                          "description": "Specifies the expiration of the cookie."
+                        },
+                        "MaxAge": {
+                          "type": "string",
+                          "pattern": "^-?\\d*?\\.?\\d\\d:\\d\\d:\\d\\d\\.?\\d{0,7}$",
+                          "description": "Specifies the maximum age of the cookie."
+                        },
+                        "SecurePolicy": {
+                          "type": "string",
+                          "enum": [
+                            "Always",
+                            "None",
+                            "SameAsRequest"
+                          ],
+                          "description": "Specifies the Secure attribute of the cookie."
+                        },
+                        "HttpOnly": {
+                          "type": "boolean",
+                          "description": "Specifies whether a cookie is accessible by client-side script."
+                        },
+                        "SameSite": {
+                          "type": "string",
+                          "enum": [
+                            "Lax",
+                            "None",
+                            "Strict",
+                            "Unspecified"
+                          ],
+                          "description": "Specifies the SameSite attribute of the cookie."
+                        },
+                        "IsEssential": {
+                          "type": "boolean",
+                          "description": "Specifies whether a cookie is essential for the application to function correctly. If true then consent policy checks may be bypassed."
+                        }
+                      }
+                    }
+                  },
+                  "required": [
+                    "AffinityKeyName"
+                  ]
+                },
+                "HealthCheck": {
+                  "type": "object",
+                  "description": "Health check configuration for destinations.",
+                  "properties": {
+                    "Active": {
+                      "type": "object",
+                      "description": "Active health checks are based on sending health probing requests.",
+                      "properties": {
+                        "Enabled": {
+                          "type": "boolean",
+                          "description": "Determines if active health checks are enabled. Defaults to false."
+                        },
+                        "Interval": {
+                          "type": "string",
+                          "pattern": "^-?\\d*?\\.?\\d\\d:\\d\\d:\\d\\d\\.?\\d{0,7}$",
+                          "description": "Period of sending health probing requests. Defaults to '00:00:15'."
+                        },
+                        "Timeout": {
+                          "type": "string",
+                          "pattern": "^-?\\d*?\\.?\\d\\d:\\d\\d:\\d\\d\\.?\\d{0,7}$",
+                          "description": "Period of waiting for a health check response. Defaults to '00:00:10'."
+                        },
+                        "Policy": {
+                          "anyOf": [
+                            {
+                              "type": "string",
+                              "enum": [
+                                "ConsecutiveFailures"
+                              ]
+                            },
+                            {
+                              "type": "string"
+                            }
+                          ],
+                          "description": "Determines the health check policy."
+                        },
+                        "Path": {
+                          "type": "string",
+                          "description": "HTTP health check endpoint path. Defaults to '/'."
+                        },
+                        "Query": {
+                          "type": "string",
+                          "description": "Query string to append to the probe, including the leading '?'."
+                        }
+                      }
+                    },
+                    "Passive": {
+                      "type": "object",
+                      "description": "Passive health checks are based on observing the health of the responses from the destination.",
+                      "properties": {
+                        "Enabled": {
+                          "type": "boolean",
+                          "description": "Determines if passive health checks are enabled. Default false."
+                        },
+                        "Policy": {
+                          "type": "string",
+                          "anyOf": [
+                            {
+                              "type": "string",
+                              "enum": [
+                                "TransportFailureRate"
+                              ]
+                            },
+                            {
+                              "type": "string"
+                            }
+                          ],
+                          "description": "Determines the health check policy."
+                        },
+                        "ReactivationPeriod": {
+                          "type": "string",
+                          "pattern": "^-?\\d*?\\.?\\d\\d:\\d\\d:\\d\\d\\.?\\d{0,7}$",
+                          "description": "Period after which an unhealthy destination reverts back to an Unknown health state."
+                        }
+                      }
+                    },
+                    "AvailableDestinationsPolicy": {
+                      "anyOf": [
+                        {
+                          "type": "string",
+                          "enum": [
+                            "HealthyAndUnknown",
+                            "HealthyOrPanic"
+                          ]
+                        },
+                        {
+                          "type": "string"
+                        }
+                      ]
+                    }
+                  }
+                },
+                "HttpClient": {
+                  "type": "object",
+                  "description": "Configuration for outbound HTTP connections.",
+                  "properties": {
+                    "SSLProtocols": {
+                      "type": "array",
+                      "description": "Specifies the SSL protocols to use.",
+                      "items": {
+                        "type": "string"
+                      }
+                    },
+                    "DangerousAcceptAnyServerCertificate": {
+                      "type": "boolean",
+                      "description": "Determines whether the server's SSL certificate validity is checked by the client. Setting it to true completely disables validation. Default value is false."
+                    },
+                    "MaxConnectionsPerServer": {
+                      "type": "number",
+                      "description": "Specifies the maximum number of connections per server."
+                    },
+                    "EnableMultipleHttp2Connections": {
+                      "type": "boolean",
+                      "description": "Determines if multiple HTTP/2 connections are enabled. Defaults to true."
+                    },
+                    "RequestHeaderEncoding": {
+                      "type": "string",
+                      "description": "Specifies the encoding of request headers, e.g. 'utf-8'."
+                    },
+                    "ResponseHeaderEncoding": {
+                      "type": "string",
+                      "description": "Specifies the encoding of response headers, e.g. 'utf-8'."
+                    },
+                    "WebProxy": {
+                      "type": "object",
+                      "description": "Config used to construct a System.Net.WebProxy instance.",
+                      "properties": {
+                        "Address": {
+                          "type": "string",
+                          "format": "iri",
+                          "description": "The URI of the proxy server."
+                        },
+                        "BypassOnLocal": {
+                          "type": "boolean",
+                          "description": "If true, bypasses the proxy for local addresses. Defaults to false."
+                        },
+                        "UseDefaultCredentials": {
+                          "type": "boolean",
+                          "description": "If true, sends CredentialCache.DefaultCredentials with requests. Defaults to false."
+                        }
+                      }
+                    }
+                  }
+                },
+                "HttpRequest": {
+                  "type": "object",
+                  "description": "Options controlling requests sent to destinations.",
+                  "properties": {
+                    "ActivityTimeout": {
+                      "type": "string",
+                      "pattern": "^-?\\d*?\\.?\\d\\d:\\d\\d:\\d\\d\\.?\\d{0,7}$",
+                      "description": "Specifies how long a request is allowed to remain idle between any operation completing, after which it will be canceled. Default is 100 seconds."
+                    },
+                    "Version": {
+                      "type": "string",
+                      "description": "Preferred version of the outgoing request. Defaults to HTTP/2."
+                    },
+                    "VersionPolicy": {
+                      "type": "string",
+                      "description": "The policy applied to version selection, e.g. whether to prefer downgrades, upgrades or request an exact version. The default is `RequestVersionOrLower`.",
+                      "enum": [
+                        "RequestVersionExact",
+                        "RequestVersionOrLower",
+                        "RequestVersionOrHigher"
+                      ]
+                    },
+                    "AllowResponseBuffering": {
+                      "type": "boolean",
+                      "description": "Determines if response buffering is allowed."
+                    }
+                  }
+                },
+                "Metadata": {
+                  "type": "object",
+                  "description": "Arbitrary key-value pairs for custom cluster logic.",
+                  "additionalProperties": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          }
         }
-    },
-    "required": [
-        "Urls",
-        "ReverseProxy"
-    ],
-    "additionalProperties": false
+      }
+    }
+  }
 }

--- a/src/ReverseProxy/Forwarder/ForwarderRequestConfig.cs
+++ b/src/ReverseProxy/Forwarder/ForwarderRequestConfig.cs
@@ -28,7 +28,7 @@ public sealed record ForwarderRequestConfig
 
     /// <summary>
     /// Preferred version of the outgoing request.
-    /// The default is HTTP/2.0.
+    /// The default is HTTP/2.
     /// </summary>
     public Version? Version { get; init; }
 

--- a/test/ReverseProxy.Tests/Yarp.ReverseProxy.Tests.csproj
+++ b/test/ReverseProxy.Tests/Yarp.ReverseProxy.Tests.csproj
@@ -8,6 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <Content Include="..\..\src\ReverseProxy\ConfigurationSchema.json" CopyToOutputDirectory="PreserveNewest" />
     <Content Include="..\TestCertificates\*.*" LinkBase="TestCertificates" CopyToOutputDirectory="PreserveNewest" />
     <Content Include="validSelfSignedClientEkuCertificate.cer">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
@@ -20,6 +21,7 @@
     <PackageReference Include="coverlet.collector" Version="$(CoverletCollectorVersion)" />
     <PackageReference Include="Moq" Version="$(MoqVersion)" />
     <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="$(MicrosoftAspNetCoreTestHostVersion)" />
+    <PackageReference Include="JsonSchema.Net" Version="$(JsonSchemaNetVersion)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/testassets/ReverseProxy.Config/appsettings.json
+++ b/testassets/ReverseProxy.Config/appsettings.json
@@ -22,20 +22,20 @@
       "cluster1": {
         "LoadBalancingPolicy": "Random",
         "SessionAffinity": {
-          "Enabled": "true",
+          "Enabled": true,
           "Policy": "Cookie",
           "AffinityKeyName": ".Yarp.Affinity"
         },
         "HealthCheck": {
           "Active": {
-            "Enabled": "true",
+            "Enabled": true,
             "Interval": "00:00:10",
             "Timeout": "00:00:10",
             "Policy": "ConsecutiveFailures",
             "Path": "/api/health"
           },
           "Passive": {
-            "Enabled": "true",
+            "Enabled": true,
             "Policy": "TransportFailureRate",
             "ReactivationPeriod": "00:05:00"
           }
@@ -55,7 +55,7 @@
       },
       "cluster2": {
         "Metadata": {
-          "CustomHealth": true
+          "CustomHealth": "true"
         },
         "Destinations": {
           "cluster2/destination1": {
@@ -93,8 +93,8 @@
           },
           { "ClientCert": "X-Client-Cert" },
 
-          { "RequestHeadersCopy": "true" },
-          { "RequestHeaderOriginalHost": "true" },
+          { "RequestHeadersCopy": true },
+          { "RequestHeaderOriginalHost": true },
           {
             "RequestHeader": "foo0",
             "Append": "bar"


### PR DESCRIPTION
Closes #1350

The intention here is to make editing the config much easier without just copy-pasting everything, it's a non-goal that it will catch every possible validation error that may be raised at runtime.
For example I've added Regex validations to some items that can catch a superset of what's actually allowed.

Initial version created by Sam
Here's the diff since then https://github.com/MihaZupan/yarp/compare/d4f177d3828970f71a48246ee84a62b42ba9c0df..json-schema?w=1#diff-fa5250031a03ad88202dff86f92ad41cc9036352784ccb1b902250d55309b9a7

![image](https://github.com/user-attachments/assets/48d9b73d-ec1d-47b4-bd9a-1618511612db)
![image](https://github.com/user-attachments/assets/cab98d84-554a-44bb-9d1a-f673e4653926)
