### PR TITLE
Make NativeAOT work on .NET 8.0

### DIFF
--- a/src/ReverseProxy/Configuration/IYarpOutputCachePolicyProvider.cs
+++ b/src/ReverseProxy/Configuration/IYarpOutputCachePolicyProvider.cs
@@ -4,6 +4,7 @@
 #if NET7_0_OR_GREATER
 using System;
 using System.Collections;
+using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 using Microsoft.AspNetCore.OutputCaching;
 using Microsoft.Extensions.Options;
@@ -24,6 +25,10 @@ internal interface IYarpOutputCachePolicyProvider
 internal sealed class YarpOutputCachePolicyProvider : IYarpOutputCachePolicyProvider
 {
 #if NET7_0_OR_GREATER
+    // Workaround for https://github.com/dotnet/yarp/issues/2598 to make YARP work with NativeAOT on .NET 8.
+    [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)]
+    private static readonly Type s_OutputCacheOptionsType = typeof(OutputCacheOptions);
+
     private readonly OutputCacheOptions _outputCacheOptions;
 
     private readonly IDictionary _policyMap;
@@ -32,14 +37,12 @@ internal sealed class YarpOutputCachePolicyProvider : IYarpOutputCachePolicyProv
     {
         _outputCacheOptions = outputCacheOptions?.Value ?? throw new ArgumentNullException(nameof(outputCacheOptions));
 
-        var type = typeof(OutputCacheOptions);
-        var flags = BindingFlags.Instance | BindingFlags.NonPublic;
-        var proprety = type.GetProperty("NamedPolicies", flags);
-        if (proprety == null || !typeof(IDictionary).IsAssignableFrom(proprety.PropertyType))
+        var property = s_OutputCacheOptionsType.GetProperty("NamedPolicies", BindingFlags.Instance | BindingFlags.NonPublic);
+        if (property == null || !typeof(IDictionary).IsAssignableFrom(property.PropertyType))
         {
             throw new NotSupportedException("This version of YARP is incompatible with the current version of ASP.NET Core.");
         }
-        _policyMap = (proprety.GetValue(_outputCacheOptions, null) as IDictionary) ?? new Dictionary<string, object>();
+        _policyMap = (property.GetValue(_outputCacheOptions, null) as IDictionary) ?? new Dictionary<string, object>();
     }
 
     public ValueTask<object?> GetPolicyAsync(string policyName)

--- a/src/ReverseProxy/Configuration/IYarpOutputCachePolicyProvider.cs
+++ b/src/ReverseProxy/Configuration/IYarpOutputCachePolicyProvider.cs
@@ -25,7 +25,7 @@ internal interface IYarpOutputCachePolicyProvider
 internal sealed class YarpOutputCachePolicyProvider : IYarpOutputCachePolicyProvider
 {
 #if NET7_0_OR_GREATER
-    // Workaround for https://github.com/dotnet/yarp/issues/2598 to make YARP work with NativeAOT on .NET 8.
+    // Workaround for https://github.com/dotnet/yarp/issues/2598 to make YARP work with NativeAOT on .NET 8. This is not needed on .NET 9+.
     [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)]
     private static readonly Type s_OutputCacheOptionsType = typeof(OutputCacheOptions);
 


### PR DESCRIPTION
Adds a workaround to make .NET 8 work.

Closes #2598