### PR TITLE
Move ResponseBodyCanceled and UpgradeResponseCanceled to debug-level log event

### DIFF
--- a/src/ReverseProxy/Forwarder/StreamCopyHttpContent.cs
+++ b/src/ReverseProxy/Forwarder/StreamCopyHttpContent.cs
@@ -167,14 +167,10 @@ internal sealed class StreamCopyHttpContent : HttpContent
             {
                 await stream.FlushAsync(cancellationToken);
             }
-            catch (OperationCanceledException oex)
-            {
-                _tcs.TrySetResult((StreamCopyResult.Canceled, oex));
-                return;
-            }
             catch (Exception ex)
             {
-                _tcs.TrySetResult((StreamCopyResult.OutputError, ex));
+                var canceled = ex is OperationCanceledException || _activityToken.CancelledByLinkedToken;
+                _tcs.TrySetResult((canceled ? StreamCopyResult.Canceled : StreamCopyResult.OutputError, ex));
                 return;
             }
 

--- a/test/ReverseProxy.Tests/Forwarder/HttpForwarderTests.cs
+++ b/test/ReverseProxy.Tests/Forwarder/HttpForwarderTests.cs
@@ -2871,7 +2871,14 @@ public class HttpForwarderTests
         Assert.Equal(error, errorFeature.Error);
         Assert.IsAssignableFrom<TException>(errorFeature.Exception);
 
-        var expectedId = error is ForwarderError.RequestCanceled or ForwarderError.RequestBodyCanceled or ForwarderError.UpgradeRequestCanceled
+        var errorIsDebugLevel = error is
+            ForwarderError.RequestCanceled or
+            ForwarderError.RequestBodyCanceled or
+            ForwarderError.ResponseBodyCanceled or
+            ForwarderError.UpgradeRequestCanceled or
+            ForwarderError.UpgradeResponseCanceled;
+
+        var expectedId = errorIsDebugLevel
             ? EventIds.ForwardingRequestCancelled
             : EventIds.ForwardingError;
 

--- a/test/ReverseProxy.Tests/Forwarder/HttpForwarderTests.cs
+++ b/test/ReverseProxy.Tests/Forwarder/HttpForwarderTests.cs
@@ -2871,14 +2871,14 @@ public class HttpForwarderTests
         Assert.Equal(error, errorFeature.Error);
         Assert.IsAssignableFrom<TException>(errorFeature.Exception);
 
-        var errorIsDebugLevel = error is
+        var errorIsRequestCancelled = error is
             ForwarderError.RequestCanceled or
             ForwarderError.RequestBodyCanceled or
             ForwarderError.ResponseBodyCanceled or
             ForwarderError.UpgradeRequestCanceled or
             ForwarderError.UpgradeResponseCanceled;
 
-        var expectedId = errorIsDebugLevel
+        var expectedId = errorIsRequestCancelled
             ? EventIds.ForwardingRequestCancelled
             : EventIds.ForwardingError;
 


### PR DESCRIPTION
Closes #2631

Same idea as #2503, but for `ResponseBodyCanceled` and `UpgradeResponseCanceled`.

`UpgradeResponseCanceled` could be an indication that the backend became unresponsive, but it's ultimately triggered by the client disconnecting. If this is a concern, the activity timeout should be lowered enough to catch such cases instead.