### PR TITLE
Remove duplicate MicrosoftDotNetXUnitExtensionsPackageVersion definition

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -15,10 +15,9 @@
     <SystemCollectionsImmutableVersion>8.0.0</SystemCollectionsImmutableVersion>
     <SystemIOHashingVersion>8.0.0</SystemIOHashingVersion>
     <MicrosoftBclTimeProviderVersion>8.0.0</MicrosoftBclTimeProviderVersion>
-    <MicrosoftDotNetXUnitExtensionsPackageVersion>10.0.0-beta.25120.6</MicrosoftDotNetXUnitExtensionsPackageVersion>
     <MicrosoftAspNetCoreTestHostVersion>6.0.36</MicrosoftAspNetCoreTestHostVersion>
     <MicrosoftCrankEventSourcesVersion>0.2.0-alpha.24576.2</MicrosoftCrankEventSourcesVersion>
-    <MicrosoftDotNetXUnitExtensionsPackageVersion>10.0.0-beta.25056.1</MicrosoftDotNetXUnitExtensionsPackageVersion>
+    <MicrosoftDotNetXUnitExtensionsPackageVersion>10.0.0-beta.25113.2</MicrosoftDotNetXUnitExtensionsPackageVersion>
     <CoverletCollectorVersion>6.0.0</CoverletCollectorVersion>
     <MoqVersion>4.18.4</MoqVersion>
     <AutofacVersion>4.9.4</AutofacVersion>


### PR DESCRIPTION
The entry got duplicated in #2710.

The arcade update that was just merged should have ran into build errors, but we were using the older version of `Microsoft.DotNet.XUnitExtensions` due to the duplication.
Using the new version is blocked on the same issue as #2762 and #2764.