### PR TITLE
Fix OTEL initialization

### DIFF
--- a/src/Application/Program.cs
+++ b/src/Application/Program.cs
@@ -6,6 +6,7 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 
+
 // Load configuration
 if (args.Length != 1)
 {


### PR DESCRIPTION
OTEL initialization failed when `YARP_UNSAFE_OLTP_CERT_ACCEPT_ANY_SERVER_CERTIFICATE` was not set to `true`