### PR TITLE
[K8s/ingress] Do not duplicate rules when endpoint has multiple ports

### DIFF
--- a/src/Kubernetes.Controller/Converters/YarpParser.cs
+++ b/src/Kubernetes.Controller/Converters/YarpParser.cs
@@ -95,6 +95,7 @@ internal static class YarpParser
         // make sure cluster is present
         foreach (var subset in subsets ?? Enumerable.Empty<V1EndpointSubset>())
         {
+            var isRoutePresent = false;
             foreach (var port in subset.Ports ?? Enumerable.Empty<Corev1EndpointPort>())
             {
                 if (!MatchesPort(port, servicePort))
@@ -102,10 +103,13 @@ internal static class YarpParser
                     continue;
                 }
 
-                var pathMatch = FixupPathMatch(path);
-                var host = rule.Host;
-
-                routes.Add(CreateRoute(ingressContext, path, cluster, pathMatch, host));
+                if (!isRoutePresent)
+                {
+                    var pathMatch = FixupPathMatch(path);
+                    var host = rule.Host;
+                    routes.Add(CreateRoute(ingressContext, path, cluster, pathMatch, host));
+                    isRoutePresent = true;
+                }
 
                 // Add destination for every endpoint address
                 foreach (var address in subset.Addresses ?? Enumerable.Empty<V1EndpointAddress>())

--- a/test/Kubernetes.Tests/IngressConversionTests.cs
+++ b/test/Kubernetes.Tests/IngressConversionTests.cs
@@ -40,6 +40,7 @@ public class IngressConversionTests
     [Theory]
     [InlineData("basic-ingress")]
     [InlineData("multiple-endpoints-ports")]
+    [InlineData("multiple-endpoints-same-port")]
     [InlineData("https")]
     [InlineData("exact-match")]
     [InlineData("annotations")]

--- a/test/Kubernetes.Tests/testassets/multiple-endpoints-same-port/clusters.json
+++ b/test/Kubernetes.Tests/testassets/multiple-endpoints-same-port/clusters.json
@@ -1,0 +1,19 @@
+[
+  {
+    "ClusterId": "frontend.default:80",
+    "LoadBalancingPolicy": null,
+    "SessionAffinity": null,
+    "HealthCheck": null,
+    "HttpClient": null,
+    "HttpRequest": null,
+    "Destinations": {
+      "http://10.244.2.38:80": {
+        "Address": "http://10.244.2.38:80",
+        "Health": null,
+        "Metadata": null
+      }
+    },
+    "Metadata": null
+  }
+]
+

--- a/test/Kubernetes.Tests/testassets/multiple-endpoints-same-port/ingress.yaml
+++ b/test/Kubernetes.Tests/testassets/multiple-endpoints-same-port/ingress.yaml
@@ -1,0 +1,49 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: minimal-ingress
+  namespace: default
+spec:
+  rules:
+  - http:
+      paths:
+      - path: /foo
+        pathType: Prefix
+        backend:
+          service:
+            name: frontend
+            port:
+              number: 80
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: frontend
+  namespace: default
+spec:
+  selector:
+    app: frontend
+  ports:
+  - name: http
+    port: 80
+    targetPort: 80
+  - name: other_http
+    port: 8080
+    targetPort: 80
+  type: ClusterIP
+---
+apiVersion: v1
+kind: Endpoints
+metadata:
+  name: frontend
+  namespace: default
+subsets:
+  - addresses:
+    - ip: 10.244.2.38
+    ports:
+    - name: http
+      port: 80
+      protocol: TCP
+    - name: other_http
+      port: 80
+      protocol: TCP

--- a/test/Kubernetes.Tests/testassets/multiple-endpoints-same-port/routes.json
+++ b/test/Kubernetes.Tests/testassets/multiple-endpoints-same-port/routes.json
@@ -1,0 +1,19 @@
+[
+  {
+    "RouteId": "minimal-ingress.default:/foo",
+    "Match": {
+      "Methods": null,
+      "Hosts": [],
+      "Path": "/foo/{**catch-all}",
+      "Headers": null,
+      "QueryParameters": null
+    },
+    "Order": null,
+    "ClusterId": "frontend.default:80",
+    "AuthorizationPolicy": null,
+    "RateLimiterPolicy": null,
+    "CorsPolicy": null,
+    "Metadata": null,
+    "Transforms": null
+  }
+]


### PR DESCRIPTION
Kubernetes allow to define multiple times the same port number with different names.

It can cause some duplicate routes to be created.

Fix #2819 