### PR TITLE
Add a YAML release pipeline

### DIFF
--- a/docs/operations/Branching.md
+++ b/docs/operations/Branching.md
@@ -18,6 +18,6 @@ Update branding in `main`:
 
 Update the runtimes and SDKs in `global.json` in `main`:
 
-Check that the global.json includes the latest 3.1 runtime versions from [here](https://dotnet.microsoft.com/download/dotnet-core/3.1), and 5.0 from [here](https://dotnet.microsoft.com/download/dotnet/5.0), and 6.0 SDK from [here](https://dotnet.microsoft.com/download/dotnet/6.0).
+Check that the global.json includes the latest 8.0 runtime versions from [here](https://dotnet.microsoft.com/download/dotnet/8.0), and 9.0 from [here](https://dotnet.microsoft.com/download/dotnet/9.0).
 
 [`eng/Versions.props`]: ../../eng/Versions.props

--- a/docs/operations/Release.md
+++ b/docs/operations/Release.md
@@ -2,7 +2,7 @@
 
 This document provides a guide on how to release a preview of YARP.
 
-To keep track of the process, open a [release checklist issue](https://github.com/dotnet/yarp/issues/new?title=Preview%20X%20release%20checklist&body=See%20%5BRelease.md%5D%28https%3A%2F%2Fgithub.com%2Fdotnet%2Fyarp%2Fblob%2Fmain%2Fdocs%2Foperations%2FRelease.md%29%20for%20detailed%20instructions.%0A%0A-%20%5B%20%5D%20Ensure%20there%27s%20a%20release%20branch%20created%20%28see%20%5BBranching%5D%28https%3A%2F%2Fgithub.com%2Fdotnet%2Fyarp%2Fblob%2Fmain%2Fdocs%2Foperations%2FBranching.md%29%29%0A-%20%5B%20%5D%20Ensure%20the%20%60Version.props%60%20has%20the%20%60PreReleaseVersionLabel%60%20updated%20to%20the%20next%20preview%0A-%20%5B%20%5D%20Identify%20and%20validate%20the%20build%20on%20the%20%60microsoft-reverse-proxy-official%60%20pipeline%0A-%20%5B%20%5D%20Release%20the%20build%0A-%20%5B%20%5D%20Tag%20the%20commit%0A-%20%5B%20%5D%20Draft%20release%20notes%0A-%20%5B%20%5D%20Publish%20release%20notes%0A-%20%5B%20%5D%20Close%20the%20%5Bold%20milestone%5D%28https%3A%2F%2Fgithub.com%2Fdotnet%2Fyarp%2Fmilestones%29%0A-%20%5B%20%5D%20Announce%20on%20social%20media%0A-%20%5B%20%5D%20Set%20the%20preview%20branch%20to%20protected%0A-%20%5B%20%5D%20Delete%20the%20%5Bprevious%20preview%20branch%5D%28https%3A%2F%2Fgithub.com%2Fdotnet%2Fyarp%2Fbranches%29%0A-%20%5B%20%5D%20Request%20source%20code%20archival).
+To keep track of the process, open a [release checklist issue](https://github.com/dotnet/yarp/issues/new?title=Preview%20X%20release%20checklist&body=See%20%5BRelease.md%5D%28https%3A%2F%2Fgithub.com%2Fdotnet%2Fyarp%2Fblob%2Fmain%2Fdocs%2Foperations%2FRelease.md%29%20for%20detailed%20instructions.%0A%0A-%20%5B%20%5D%20Ensure%20there%27s%20a%20release%20branch%20created%20%28see%20%5BBranching%5D%28https%3A%2F%2Fgithub.com%2Fdotnet%2Fyarp%2Fblob%2Fmain%2Fdocs%2Foperations%2FBranching.md%29%29%0A-%20%5B%20%5D%20Ensure%20the%20%60Version.props%60%20has%20the%20%60PreReleaseVersionLabel%60%20updated%20to%20the%20next%20preview%0A-%20%5B%20%5D%20Identify%20and%20validate%20the%20build%20on%20the%20%60dotnet-yarp-official%60%20pipeline%0A-%20%5B%20%5D%20Release%20the%20build%0A-%20%5B%20%5D%20Tag%20the%20commit%0A-%20%5B%20%5D%20Draft%20release%20notes%0A-%20%5B%20%5D%20Publish%20release%20notes%0A-%20%5B%20%5D%20Close%20the%20%5Bold%20milestone%5D%28https%3A%2F%2Fgithub.com%2Fdotnet%2Fyarp%2Fmilestones%29%0A-%20%5B%20%5D%20Announce%20on%20social%20media%0A-%20%5B%20%5D%20Set%20the%20preview%20branch%20to%20protected%0A-%20%5B%20%5D%20Delete%20the%20%5Bprevious%20preview%20branch%5D%28https%3A%2F%2Fgithub.com%2Fdotnet%2Fyarp%2Fbranches%29%0A-%20%5B%20%5D%20Request%20source%20code%20archival).
 
 ## Versioning
 
@@ -17,7 +17,7 @@ See [Branching](Branching.md):
 
 ## Identify the Final Build
 
-First, identify the final build of the [`microsoft-reverse-proxy-official` Azure Pipeline](https://dev.azure.com/dnceng/internal/_build?definitionId=809&_a=summary) (on dnceng/internal). The final build will be the latest successful build **in the relevant `release/x` branch**. Use the "Branches" tab on Azure DevOps to help identify it. If the branch hasn't been mirrored yet (see [code-mirror pipeline](https://dev.azure.com/dnceng/internal/_build?definitionId=16&keywordFilter=microsoft%20reverse-proxy)) and there are no outstanding changesets in the branch, the build of the corresponding commit from the main branch can be used.
+First, identify the final build of the [`dotnet-yarp-official` Azure Pipeline](https://dev.azure.com/dnceng/internal/_build?definitionId=809&_a=summary) (on dnceng/internal). The final build will be the latest successful build **in the relevant `release/x` branch**. Use the "Branches" tab on Azure DevOps to help identify it. If the branch hasn't been mirrored yet (see [`dotnet-mirror-dnceng` pipeline](https://dev.azure.com/dnceng/internal/_build?definitionId=1387)) and there are no outstanding changesets in the branch, the build of the corresponding commit from the main branch can be used.
 
 Once you've identified that build, click in to the build details.
 
@@ -25,11 +25,11 @@ Once you've identified that build, click in to the build details.
 
 At this point, you can perform any validation that makes sense. At a minimum, we should validate that the sample can run with the candidate packages. You can download the final build using the "Artifacts" which can be accessed under "Related" in the header:
 
-![image](https://user-images.githubusercontent.com/7574/81447119-e4204800-9130-11ea-8952-9a0f9831f678.png)
+![image](https://github.com/user-attachments/assets/27ddf12d-f4b7-4faa-862e-d2d1d6eafea9)
 
 The packages can be accessed from the `PackageArtifacts` artifact:
 
-![image](https://user-images.githubusercontent.com/7574/81447168-fef2bc80-9130-11ea-8aa0-5a83d90efa0d.png)
+![image](https://github.com/user-attachments/assets/264b8c6d-8108-4536-a61b-421aa652df73)
 
 ### Consume .nupkg
 
@@ -42,33 +42,32 @@ Also validate any major new scenarios this release and their associated docs.
 
 ## Release the build
 
-Once validation has been completed, it's time to release. Go back to the Final Build in Azure DevOps. It's probably good to triple-check the version numbers of the packages in the artifacts against whatever validation was done at this point.
+Once validation has been completed, it's time to release.
 
-Select "Release" from the triple-dot menu in the top-right of the build details page:
+Go to the [`dotnet-yarp-release` pipeline](https://dev.azure.com/dnceng/internal/_build?definitionId=1448) and select "Run Pipeline".
 
-![image](https://user-images.githubusercontent.com/7574/81447354-55f89180-9131-11ea-84bc-0138d7b211e4.png)
+Under "Resources", select the pipeline run that you've validated artifacts for.
 
-Verify the Release Pipeline selected is `microsoft-reverse-proxy-release`, that the `NuGet.org` stage has a blue border (meaning it will automatically deploy) and that the build number under Artifacts matches the build number of the final build (it will not match the package version). The defaults selected by Azure Pipelines should configure everything correctly but it's a good idea to double check.
+![image](https://github.com/user-attachments/assets/efa38319-2620-4deb-aca3-d2bf23c991cc)
+![image](https://github.com/user-attachments/assets/e25419e6-498d-4cc2-bf98-b5b2bc77c251)
+![image](https://github.com/user-attachments/assets/e2f7f965-b4f7-40dc-ba2f-6a91062271d5)
 
-![image](https://user-images.githubusercontent.com/7574/81447433-76c0e700-9131-11ea-9e8b-e4984ab7c31a.png)
+Triple-check the version numbers of the packages in the artifacts against whatever validation was done at this point.
 
-Click "Create" to start the release! Unless you're a release approver, you're done here!
+![image](https://github.com/user-attachments/assets/187d65d9-3c0f-4418-ab13-a77e0ad1b8e9)
+
+Select "Run". Unless you're a release approver, you're done here!
 
 ## Approve the release
 
-The Azure Pipeline will send an email to all the release approvers asking one of them to approve the release:
+The Azure Pipeline will send an email to all the release approvers asking one of them to approve the release.
 
-![image](https://user-images.githubusercontent.com/7574/81447680-f3ec5c00-9131-11ea-821c-37dbe467faee.png)
+![image](https://github.com/user-attachments/assets/e772e31c-8aea-4bca-a21f-8bd62f61365f)
 
-Click "View Approval", or navigate to the release directly in Azure DevOps. You'll see that the stage is "Pending Approval"
+Click "Review Manual Validation", or navigate to the release pipeline directly in Azure DevOps. You'll see that the stage is "Pending Approval"
 
-![image](https://user-images.githubusercontent.com/7574/81447753-10889400-9132-11ea-9dd2-26b2f6bc8970.png)
-
-Click "Approve" to bring up the Approval dialog. Enter a comment such as "release for preview X" and click "Approve" to finalize the release. **After pressing "Approve", packages will be published automatically**. It *is* possible to cancel the pipeline, but it might be too late. See "Troubleshooting" below.
-
-![image](https://user-images.githubusercontent.com/7574/81447898-4d548b00-9132-11ea-89df-b4624a5e037d.png)
-
-Click "Reject" to cancel the release.
+Enter a comment such as "release for preview X" approve finalize the release.
+**After approving, packages will be published automatically**. It *is* possible to cancel the pipeline, but it might be too late. See "Troubleshooting" below.
 
 The packages will be pushed and when the "NuGet.org" stage turns green, the packages are published!
 
@@ -82,7 +81,7 @@ Create and push a git tag for the commit associated with the final build (not ne
 
 Push the tag change to the upstream repo (**not your fork**)
 
-`git push upstream --tags`
+`git push upstream v1.0.0-previewX`
 
 ## Draft release notes
 

--- a/dotnet-yarp-release.yml
+++ b/dotnet-yarp-release.yml
@@ -1,0 +1,82 @@
+trigger: none
+name: $(Date:yyyyMMdd).$(Rev:r)
+
+variables:
+- name: NuGetApiKey
+  value: 
+- name: NuGetFeed
+  value: https://api.nuget.org/v3/index.json
+
+resources:
+  repositories:
+  - repository: 1ESPipelineTemplates
+    type: git
+    name: 1ESPipelineTemplates/1ESPipelineTemplates
+    ref: refs/tags/release
+  pipelines:
+  - pipeline: yarp-build
+    source: dotnet\yarp\dotnet-yarp-official
+
+extends:
+  template: v1/1ES.Official.PipelineTemplate.yml@1ESPipelineTemplates
+  parameters:
+    pool:
+      name: NetCore1ESPool-Internal
+      image: 1es-windows-2022
+      os: windows
+
+    stages:
+    - stage: release
+      displayName: Release to NuGet
+      jobs:
+      - job: PreDeploymentApprovalJob
+        displayName: Pre-Deployment Approval
+        condition: succeeded()
+        timeoutInMinutes: 2880
+        pool: server
+        steps:
+        - task: ManualValidation@1
+          inputs:
+            notifyUsers: |-
+              karelz@microsoft.com,
+              samsp@microsoft.com,
+              adityam@microsoft.com,
+              mizupan@microsoft.com
+            approvers: |-
+              karelz@microsoft.com,
+              samsp@microsoft.com,
+              adityam@microsoft.com
+
+      - job: NuGetPush
+        dependsOn: PreDeploymentApprovalJob
+        condition: succeeded()
+        timeoutInMinutes: 30
+        templateContext:
+          type: releaseJob
+          isProduction: true
+          inputs:
+          - input: pipelineArtifact
+            pipeline: yarp-build
+            artifactName: artifacts
+        steps:
+        - task: NuGetToolInstaller@1
+          displayName: Prepare NuGet tool
+        - task: PowerShell@2
+          displayName: NuGet push
+          inputs:
+            targetType: inline
+            script: |
+              tree $(Pipeline.Workspace)\Release\Shipping /f
+
+              Get-ChildItem "$(Pipeline.Workspace)\Release\Shipping\*" -Filter *.nupkg -Exclude *.symbols.nupkg | ForEach-Object {
+                  $name = $_.Name
+                  Write-Host "Processing $name ..."
+                  if ($name.StartsWith("Yarp.ReverseProxy.") -or $name.StartsWith("Yarp.Telemetry.Consumption.")) {
+                      Write-Host "  Publishing $name"
+                      nuget push -Source $env:NuGetFeed -ApiKey $env:NuGetApiKey $_.FullName
+                  } else {
+                      Write-Host "  Skipping $name (update the script to change this)"
+                  }
+              }
+          env:
+            NuGetApiKey: $(NuGetApiKey)

--- a/dotnet-yarp-release.yml
+++ b/dotnet-yarp-release.yml
@@ -41,7 +41,8 @@ extends:
               karelz@microsoft.com,
               samsp@microsoft.com,
               adityam@microsoft.com,
-              mizupan@microsoft.com
+              mizupan@microsoft.com,
+              bpetit@microsoft.com
             approvers: |-
               karelz@microsoft.com,
               samsp@microsoft.com,


### PR DESCRIPTION
This replaces the obsolete "classic" release pipeline with a YAML-based one.

I've done as much validation as possible without actually pushing to NuGet (using the same YAML as in this PR, but with commented-out `nuget push`.