### PR TITLE
Suppress CodeQL SM02373 Secure-only cookies warning

### DIFF
--- a/src/ReverseProxy/SessionAffinity/BaseHashCookieSessionAffinityPolicy.cs
+++ b/src/ReverseProxy/SessionAffinity/BaseHashCookieSessionAffinityPolicy.cs
@@ -42,6 +42,8 @@ internal abstract class BaseHashCookieSessionAffinityPolicy : ISessionAffinityPo
         {
             var affinityKey = GetDestinationHash(destination);
             var affinityCookieOptions = AffinityHelpers.CreateCookieOptions(config.Cookie, context.Request.IsHttps, _timeProvider);
+
+            // CodeQL [SM02373] - Whether CookieOptions.Secure is used depends on YARP configuration, and session affinity may be used in non-HTTPS setups. Hash-based affinity policies do not intend to provide privacy protection. See https://learn.microsoft.com/aspnet/core/fundamentals/servers/yarp/session-affinity#key-protection.
             context.Response.Cookies.Append(config.AffinityKeyName, affinityKey, affinityCookieOptions);
         }
     }

--- a/src/ReverseProxy/SessionAffinity/CookieSessionAffinityPolicy.cs
+++ b/src/ReverseProxy/SessionAffinity/CookieSessionAffinityPolicy.cs
@@ -39,6 +39,8 @@ internal sealed class CookieSessionAffinityPolicy : BaseEncryptedSessionAffinity
     protected override void SetAffinityKey(HttpContext context, ClusterState cluster, SessionAffinityConfig config, string unencryptedKey)
     {
         var affinityCookieOptions = AffinityHelpers.CreateCookieOptions(config.Cookie, context.Request.IsHttps, _timeProvider);
+
+        // CodeQL [SM02373] - Whether CookieOptions.Secure is used depends on YARP configuration, and session affinity may be used in non-HTTPS setups. Cookie values are encrypted using ASP.NET DataProtection. See https://learn.microsoft.com/aspnet/core/fundamentals/servers/yarp/session-affinity#key-protection.
         context.Response.Cookies.Append(config.AffinityKeyName, Protect(unencryptedKey), affinityCookieOptions);
     }
 }


### PR DESCRIPTION
Suppressing as a false positive.
Whether `Secure` is used depends on configuration (defaults to false). If you're not using HTTPS, it's still reasonable that you might want to use session affinity.
The values in our case aren't specific to the user and are either a) not considered sensitive (e.g. hash-based policies), or b) are encrypted using DataProtection.
The cookie names may indicate which clusters a user has previously used.