### PR TITLE
Introduce service port driven backend protocol to support different protocols routing in same ingress.

### DIFF
--- a/src/Kubernetes.Controller/Converters/YarpParser.cs
+++ b/src/Kubernetes.Controller/Converters/YarpParser.cs
@@ -122,7 +122,17 @@ internal static class YarpParser
 
     private static void AddDestination(ClusterTransfer cluster, YarpIngressContext ingressContext, string host, int? port)
     {
-        var protocol = ingressContext.Options.Https ? "https" : "http";
+        var protocol = "http";
+
+        if (ingressContext.Options.Https)
+        {
+            protocol = "https";
+        } else if (cluster.ClusterId.Contains(':'))
+        {
+            var portPart = cluster.ClusterId.Split(':').Last().ToLower();
+            protocol = (portPart.EndsWith("443") || portPart.Contains("https")) ? "https" : "http";
+        }
+
         var uri = $"{protocol}://{host}";
         if (port.HasValue)
         {

--- a/src/Kubernetes.Controller/Converters/YarpParser.cs
+++ b/src/Kubernetes.Controller/Converters/YarpParser.cs
@@ -129,7 +129,7 @@ internal static class YarpParser
             protocol = "https";
         } else if (cluster.ClusterId.Contains(':'))
         {
-            var portPart = cluster.ClusterId.Split(':').Last().ToLower();
+            var portPart = cluster.ClusterId.Split(':')[^1]. ToLowerInvariant();
             protocol = (portPart.EndsWith("443") || portPart.Contains("https")) ? "https" : "http";
         }
 

--- a/src/Kubernetes.Controller/Converters/YarpParser.cs
+++ b/src/Kubernetes.Controller/Converters/YarpParser.cs
@@ -130,7 +130,7 @@ internal static class YarpParser
         } else if (cluster.ClusterId.Contains(':'))
         {
             var portPart = cluster.ClusterId.Split(':')[^1]. ToLowerInvariant();
-            protocol = (portPart.EndsWith("443") || portPart.Contains("https")) ? "https" : "http";
+            protocol = (portPart.EndsWith("443", StringComparison.Ordinal) || portPart.StartsWith("https", StringComparison.Ordinal)) ? "https" : "http";
         }
 
         var uri = $"{protocol}://{host}";

--- a/src/Kubernetes.Controller/Converters/YarpParser.cs
+++ b/src/Kubernetes.Controller/Converters/YarpParser.cs
@@ -122,16 +122,12 @@ internal static class YarpParser
 
     private static void AddDestination(ClusterTransfer cluster, YarpIngressContext ingressContext, string host, int? port)
     {
-        var protocol = "http";
+        var isHttps =
+            ingressContext.Options.Https ||
+            cluster.ClusterId.EndsWith(":443", StringComparison.Ordinal) ||
+            cluster.ClusterId.EndsWith(":https", StringComparison.OrdinalIgnoreCase);
 
-        if (ingressContext.Options.Https)
-        {
-            protocol = "https";
-        } else if (cluster.ClusterId.Contains(':'))
-        {
-            var portPart = cluster.ClusterId.Split(':')[^1]. ToLowerInvariant();
-            protocol = (portPart.EndsWith("443", StringComparison.Ordinal) || portPart.StartsWith("https", StringComparison.Ordinal)) ? "https" : "http";
-        }
+        var protocol = isHttps ? "https" : "http";
 
         var uri = $"{protocol}://{host}";
         if (port.HasValue)

--- a/test/Kubernetes.Tests/IngressConversionTests.cs
+++ b/test/Kubernetes.Tests/IngressConversionTests.cs
@@ -42,6 +42,7 @@ public class IngressConversionTests
     [InlineData("multiple-endpoints-ports")]
     [InlineData("multiple-endpoints-same-port")]
     [InlineData("https")]
+    [InlineData("https-service-port-protocol")]
     [InlineData("exact-match")]
     [InlineData("annotations")]
     [InlineData("mapped-port")]

--- a/test/Kubernetes.Tests/testassets/external-name-ingress/clusters.json
+++ b/test/Kubernetes.Tests/testassets/external-name-ingress/clusters.json
@@ -7,8 +7,8 @@
     "HttpClient": null,
     "HttpRequest": null,
     "Destinations": {
-      "http://external-service.example.com:443": {
-        "Address": "http://external-service.example.com:443",
+      "https://external-service.example.com:443": {
+        "Address": "https://external-service.example.com:443",
         "Health": null,
         "Metadata": null
       }

--- a/test/Kubernetes.Tests/testassets/https-service-port-protocol/clusters.json
+++ b/test/Kubernetes.Tests/testassets/https-service-port-protocol/clusters.json
@@ -1,0 +1,50 @@
+[
+  {
+    "ClusterId": "frontend.default:443",
+    "LoadBalancingPolicy": null,
+    "SessionAffinity": null,
+    "HealthCheck": null,
+    "HttpClient": null,
+    "HttpRequest": null,
+    "Destinations": {
+      "https://10.244.2.38:443": {
+        "Address": "https://10.244.2.38:443",
+        "Health": null,
+        "Metadata": null
+      }
+    },
+    "Metadata": null
+  },
+  {
+    "ClusterId": "frontend.default:https",
+    "LoadBalancingPolicy": null,
+    "SessionAffinity": null,
+    "HealthCheck": null,
+    "HttpClient": null,
+    "HttpRequest": null,
+    "Destinations": {
+      "https://10.244.2.38:443": {
+        "Address": "https://10.244.2.38:443",
+        "Health": null,
+        "Metadata": null
+      }
+    },
+    "Metadata": null
+  },
+  {
+    "ClusterId": "frontend.default:80",
+    "LoadBalancingPolicy": null,
+    "SessionAffinity": null,
+    "HealthCheck": null,
+    "HttpClient": null,
+    "HttpRequest": null,
+    "Destinations": {
+      "http://10.244.2.38:80": {
+        "Address": "http://10.244.2.38:80",
+        "Health": null,
+        "Metadata": null
+      }
+    },
+    "Metadata": null
+  }
+]

--- a/test/Kubernetes.Tests/testassets/https-service-port-protocol/ingress.yaml
+++ b/test/Kubernetes.Tests/testassets/https-service-port-protocol/ingress.yaml
@@ -1,0 +1,63 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: minimal-ingress
+  namespace: default
+spec:
+  rules:
+    - http:
+        paths:
+          - path: /foo
+            pathType: Prefix
+            backend:
+              service:
+                name: frontend
+                port:
+                  number: 443
+          - path: /fee
+            pathType: Prefix
+            backend:
+              service:
+                name: frontend
+                port:
+                  name: https
+          - path: /faa
+            pathType: Prefix
+            backend:
+              service:
+                name: frontend
+                port:
+                  number: 80
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: frontend
+  namespace: default
+spec:
+  selector:
+    app: frontend
+  ports:
+    - name: https
+      port: 443
+      targetPort: 443
+    - name: http
+      port: 80
+      targetPort: 80
+  type: ClusterIP
+---
+apiVersion: v1
+kind: Endpoints
+metadata:
+  name: frontend
+  namespace: default
+subsets:
+  - addresses:
+      - ip: 10.244.2.38
+    ports:
+      - name: https
+        port: 443
+        protocol: TCP
+      - name: http
+        port: 80
+        protocol: TCP

--- a/test/Kubernetes.Tests/testassets/https-service-port-protocol/routes.json
+++ b/test/Kubernetes.Tests/testassets/https-service-port-protocol/routes.json
@@ -1,0 +1,53 @@
+[
+  {
+    "RouteId": "minimal-ingress.default:/foo",
+    "Match": {
+      "Methods": null,
+      "Hosts": [],
+      "Path": "/foo/{**catch-all}",
+      "Headers": null,
+      "QueryParameters": null
+    },
+    "Order": null,
+    "ClusterId": "frontend.default:443",
+    "AuthorizationPolicy": null,
+    "RateLimiterPolicy": null,
+    "CorsPolicy": null,
+    "Metadata": null,
+    "Transforms": null
+  },
+  {
+    "RouteId": "minimal-ingress.default:/fee",
+    "Match": {
+      "Methods": null,
+      "Hosts": [],
+      "Path": "/fee/{**catch-all}",
+      "Headers": null,
+      "QueryParameters": null
+    },
+    "Order": null,
+    "ClusterId": "frontend.default:https",
+    "AuthorizationPolicy": null,
+    "RateLimiterPolicy": null,
+    "CorsPolicy": null,
+    "Metadata": null,
+    "Transforms": null
+  },
+  {
+    "RouteId": "minimal-ingress.default:/faa",
+    "Match": {
+      "Methods": null,
+      "Hosts": [],
+      "Path": "/faa/{**catch-all}",
+      "Headers": null,
+      "QueryParameters": null
+    },
+    "Order": null,
+    "ClusterId": "frontend.default:80",
+    "AuthorizationPolicy": null,
+    "RateLimiterPolicy": null,
+    "CorsPolicy": null,
+    "Metadata": null,
+    "Transforms": null
+  }
+]


### PR DESCRIPTION
As of this moment, having multiple entries with different protocols in the same ingress results in failed routing.
Therefore, I would suggest introducing an adjusted service port driven protocol detection.

See how traefik does it for reference: https://doc.traefik.io/traefik/routing/providers/kubernetes-ingress/#communication-between-traefik-and-pods