### PR TITLE
[Container] Add OutputCache configuration from file

### DIFF
--- a/src/Application/Program.cs
+++ b/src/Application/Program.cs
@@ -5,6 +5,7 @@ using Microsoft.AspNetCore.Builder;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
+using Yarp.ReverseProxy.Configuration;
 
 
 // Load configuration
@@ -26,12 +27,11 @@ builder.Configuration.AddJsonFile(fileInfo.FullName, optional: false, reloadOnCh
 
 // Configure YARP
 builder.AddServiceDefaults();
-builder.Services.AddServiceDiscovery();
+builder.Services.AddServiceDiscovery()
+                .AddOutputCache(builder.Configuration.GetSection("OutputCache"));
 builder.Services.AddReverseProxy()
                 .LoadFromConfig(builder.Configuration.GetSection("ReverseProxy"))
                 .AddServiceDiscoveryDestinationResolver();
-
-Console.WriteLine(builder.Configuration.GetSection("ReverseProxy").Value);
 
 var app = builder.Build();
 app.MapReverseProxy();

--- a/src/Application/Yarp.Application.csproj
+++ b/src/Application/Yarp.Application.csproj
@@ -7,6 +7,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <AssemblyName>yarp</AssemblyName>
+    <EnableConfigurationBindingGenerator>true</EnableConfigurationBindingGenerator>
   </PropertyGroup>
 
   <!-- Used by publishing infrastructure to get the version to use for blob publishing -->

--- a/src/Application/Yarp.Application.csproj
+++ b/src/Application/Yarp.Application.csproj
@@ -13,7 +13,6 @@
   <Target Name="ReturnPackageVersion" Returns="$(PackageVersion)" />
 
   <ItemGroup>
-    <PackageReference Include="Yarp.ReverseProxy" Version="$(YarpNugetVersion)" />
     <PackageReference Include="Microsoft.Extensions.ServiceDiscovery" Version="$(MicrosoftExtensionsServiceDiscovery)" />
     <PackageReference Include="Microsoft.Extensions.ServiceDiscovery.Yarp" Version="$(MicrosoftExtensionsServiceDiscoveryYarp)" />
 
@@ -23,6 +22,10 @@
     <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="$(OpenTelemetryInstrumentationHttp)" />
     <PackageReference Include="OpenTelemetry.Instrumentation.Runtime" Version="$(OpenTelemetryInstrumentationRuntime)" />
     <PackageReference Include="AspNetCore.HealthChecks.ApplicationStatus" Version="$(AspNetCoreHealthChecksApplicationStatus)" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\ReverseProxy\Yarp.ReverseProxy.csproj" />
   </ItemGroup>
 
 </Project>

--- a/src/ReverseProxy/Configuration/Middlewares/OutputCacheConfig.cs
+++ b/src/ReverseProxy/Configuration/Middlewares/OutputCacheConfig.cs
@@ -47,7 +47,7 @@ public sealed record NamedCacheConfig
     public bool ExcludeDefaultPolicy { get; set; }
 
     /// <inheritdoc cref="OutputCachePolicyBuilder.Expire(TimeSpan)"/>
-    public TimeSpan? ExpirationTime { get; set; }
+    public TimeSpan? ExpirationTimeSpan { get; set; }
 
     /// <inheritdoc cref="OutputCachePolicyBuilder.NoCache"/>
     public bool NoCache { get; set; }
@@ -107,8 +107,8 @@ public static class OutputCacheConfigExtensions
 
     private static void PolicyBuilder(OutputCachePolicyBuilder builder, NamedCacheConfig policy)
     {
-        if (policy.Duration.HasValue)
-            builder.Expire(policy.Duration.Value);
+        if (policy.ExpirationTimeSpan.HasValue)
+            builder.Expire(policy.ExpirationTimeSpan.Value);
 
         if (policy.NoCache)
             builder.NoCache();

--- a/src/ReverseProxy/Configuration/Middlewares/OutputCacheConfig.cs
+++ b/src/ReverseProxy/Configuration/Middlewares/OutputCacheConfig.cs
@@ -1,0 +1,122 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.OutputCaching;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Yarp.ReverseProxy.Configuration;
+
+/// <summary>
+/// Configuration for <see cref="OutputCacheOptions"/>
+/// </summary>
+public class OutputCacheConfig
+{
+    /// <inheritdoc cref="OutputCacheOptions.SizeLimit"/>
+    public long SizeLimit { get; set; } = 100 * 1024 * 1024;
+
+    /// <inheritdoc cref="OutputCacheOptions.MaximumBodySize"/>
+    public long MaximumBodySize { get; set; } = 64 * 1024 * 1024;
+
+    /// <inheritdoc cref="OutputCacheOptions.DefaultExpirationTimeSpan"/>
+    public TimeSpan DefaultExpirationTimeSpan { get; set; } = TimeSpan.FromSeconds(60);
+
+    /// <inheritdoc cref="OutputCacheOptions.UseCaseSensitivePaths"/>
+    public bool UseCaseSensitivePaths { get; set; }
+
+    /// <summary>
+    /// Policies that will be added with <see cref="OutputCacheOptions.AddBasePolicy(Action{OutputCachePolicyBuilder}, bool)"/>
+    /// </summary>
+    public IDictionary<string, NamedCacheConfig> NamedPolicies { get; set; } = new Dictionary<string, NamedCacheConfig>(StringComparer.InvariantCultureIgnoreCase);
+}
+
+/// <summary>
+/// Configuration for <see cref="OutputCachePolicyBuilder"/>
+/// </summary>
+public class NamedCacheConfig
+{
+    /// <summary>
+    /// Flag to exclude or not the default policy
+    /// </summary>
+    public bool ExcludeDefaultPolicy { get; set; }
+
+    /// <inheritdoc cref="OutputCachePolicyBuilder.Expire(TimeSpan)"/>
+    public TimeSpan? Duration { get; set; }
+
+    /// <inheritdoc cref="OutputCachePolicyBuilder.NoCache"/>
+    public bool NoCache { get; set; }
+
+    /// <inheritdoc cref="OutputCachePolicyBuilder.SetVaryByQuery(string[])"/>
+    public string[]? VaryByQueryKeys { get; set; }
+
+    /// <inheritdoc cref="OutputCachePolicyBuilder.SetVaryByHeader(string[])"/>
+    public string[]? VaryByHeaders { get; set; }
+}
+
+/// <summary>
+/// Collections of extensions to configure OutputCache
+/// </summary>
+public static class OutputCacheConfigExtensions
+{
+    /// <summary>
+    /// Add and configure OuputCache
+    /// </summary>
+    public static IServiceCollection AddOutputCache(this IServiceCollection services, IConfiguration config)
+    {
+        if (config == null)
+        {
+            return services;
+        }
+
+        var outputCacheConfig = config.Get<OutputCacheConfig>();
+
+        if (outputCacheConfig != null)
+        {
+            services.AddOutputCache(outputCacheConfig);
+        }
+
+        return services;
+    }
+
+    // <summary>
+    /// Add and configure OuputCache
+    /// </summary>
+    public static IServiceCollection AddOutputCache(this IServiceCollection services, OutputCacheConfig config)
+    {
+        return services.AddOutputCache(options =>
+        {
+            options.SizeLimit = config.SizeLimit;
+            options.MaximumBodySize = config.MaximumBodySize;
+            options.DefaultExpirationTimeSpan = config.DefaultExpirationTimeSpan;
+            options.UseCaseSensitivePaths = config.UseCaseSensitivePaths;
+
+            foreach (var policy  in config.NamedPolicies)
+            {
+                options.AddPolicy(policy.Key,
+                    builder => PolicyBuilder(builder, policy.Value),
+                    policy.Value.ExcludeDefaultPolicy);
+            }
+        });
+    }
+
+    private static void PolicyBuilder(OutputCachePolicyBuilder builder, NamedCacheConfig policy)
+    {
+        if (policy.Duration.HasValue)
+            builder.Expire(policy.Duration.Value);
+
+        if (policy.NoCache)
+            builder.NoCache();
+
+        if (policy.VaryByQueryKeys != null)
+            builder.SetVaryByQuery(policy.VaryByQueryKeys);
+
+        if (policy.VaryByHeaders != null)
+            builder.SetVaryByHeader(policy.VaryByHeaders);
+    }
+}

--- a/src/ReverseProxy/Configuration/Middlewares/OutputCacheConfig.cs
+++ b/src/ReverseProxy/Configuration/Middlewares/OutputCacheConfig.cs
@@ -47,7 +47,7 @@ public sealed record NamedCacheConfig
     public bool ExcludeDefaultPolicy { get; set; }
 
     /// <inheritdoc cref="OutputCachePolicyBuilder.Expire(TimeSpan)"/>
-    public TimeSpan? Duration { get; set; }
+    public TimeSpan? ExpirationTime { get; set; }
 
     /// <inheritdoc cref="OutputCachePolicyBuilder.NoCache"/>
     public bool NoCache { get; set; }

--- a/src/ReverseProxy/Configuration/Middlewares/OutputCacheConfig.cs
+++ b/src/ReverseProxy/Configuration/Middlewares/OutputCacheConfig.cs
@@ -16,7 +16,7 @@ namespace Yarp.ReverseProxy.Configuration;
 /// <summary>
 /// Configuration for <see cref="OutputCacheOptions"/>
 /// </summary>
-public class OutputCacheConfig
+public sealed record OutputCacheConfig
 {
     /// <inheritdoc cref="OutputCacheOptions.SizeLimit"/>
     public long SizeLimit { get; set; } = 100 * 1024 * 1024;
@@ -33,13 +33,13 @@ public class OutputCacheConfig
     /// <summary>
     /// Policies that will be added with <see cref="OutputCacheOptions.AddBasePolicy(Action{OutputCachePolicyBuilder}, bool)"/>
     /// </summary>
-    public IDictionary<string, NamedCacheConfig> NamedPolicies { get; set; } = new Dictionary<string, NamedCacheConfig>(StringComparer.InvariantCultureIgnoreCase);
+    public IDictionary<string, NamedCacheConfig> NamedPolicies { get; set; } = new Dictionary<string, NamedCacheConfig>(StringComparer.OrdinalIgnoreCase);
 }
 
 /// <summary>
 /// Configuration for <see cref="OutputCachePolicyBuilder"/>
 /// </summary>
-public class NamedCacheConfig
+public sealed record NamedCacheConfig
 {
     /// <summary>
     /// Flag to exclude or not the default policy
@@ -84,7 +84,7 @@ public static class OutputCacheConfigExtensions
         return services;
     }
 
-    // <summary>
+    /// <summary>
     /// Add and configure OuputCache
     /// </summary>
     public static IServiceCollection AddOutputCache(this IServiceCollection services, OutputCacheConfig config)

--- a/src/ReverseProxy/Yarp.ReverseProxy.csproj
+++ b/src/ReverseProxy/Yarp.ReverseProxy.csproj
@@ -10,6 +10,8 @@
     <IsAotCompatible>true</IsAotCompatible>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageTags>yarp;dotnet;reverse-proxy;aspnetcore</PackageTags>
+    <EnableConfigurationBindingGenerator>true</EnableConfigurationBindingGenerator>
+    <InterceptorsNamespaces>$(InterceptorsNamespaces);Microsoft.Extensions.Configuration.Binder.SourceGeneration</InterceptorsNamespaces>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/ReverseProxy.Tests/Configuration/OutputCacheConfigTests.cs
+++ b/test/ReverseProxy.Tests/Configuration/OutputCacheConfigTests.cs
@@ -22,9 +22,9 @@ public class OutputCacheConfigTests
         config.MaximumBodySize = 10;
         config.SizeLimit = 20;
         config.UseCaseSensitivePaths = true;
-        config.NamedPolicies.Add("test1", new NamedCacheConfig { Duration = TimeSpan.FromSeconds(5), ExcludeDefaultPolicy = true });
-        config.NamedPolicies.Add("test2", new NamedCacheConfig { Duration = TimeSpan.FromSeconds(15), ExcludeDefaultPolicy = false });
-        config.NamedPolicies.Add("test3", new NamedCacheConfig { Duration = TimeSpan.FromSeconds(3), ExcludeDefaultPolicy = true, VaryByHeaders = new[] { "X-SomeHeader" } });
+        config.NamedPolicies.Add("test1", new NamedCacheConfig { ExpirationTimeSpan = TimeSpan.FromSeconds(5), ExcludeDefaultPolicy = true });
+        config.NamedPolicies.Add("test2", new NamedCacheConfig { ExpirationTimeSpan = TimeSpan.FromSeconds(15), ExcludeDefaultPolicy = false });
+        config.NamedPolicies.Add("test3", new NamedCacheConfig { ExpirationTimeSpan = TimeSpan.FromSeconds(3), ExcludeDefaultPolicy = true, VaryByHeaders = new[] { "X-SomeHeader" } });
 
         var builder = WebApplication.CreateBuilder();
         builder.Services.AddOutputCache(config)
@@ -55,15 +55,15 @@ public class OutputCacheConfigTests
                     "UseCaseSensitivePaths": true,
                     "NamedPolicies": {
                         "test1": {
-                            "Duration": "00:05:00",
+                            "ExpirationTimeSpan": "00:05:00",
                             "ExcludeDefaultPolicy": true
                         },
                         "test2": {
-                            "Duration": "00:15:00",
+                            "ExpirationTimeSpan": "00:15:00",
                             "ExcludeDefaultPolicy": false
                         },
                         "test3": {
-                            "Duration": "00:03:00",
+                            "ExpirationTimeSpan": "00:03:00",
                             "ExcludeDefaultPolicy": true,
                             "VaryByHeaders": [ "X-SomeHeader" ]
                         }

--- a/test/ReverseProxy.Tests/Configuration/OutputCacheConfigTests.cs
+++ b/test/ReverseProxy.Tests/Configuration/OutputCacheConfigTests.cs
@@ -1,0 +1,93 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.IO;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace Yarp.ReverseProxy.Configuration;
+
+public class OutputCacheConfigTests
+{
+    [Fact]
+    public async Task All_Options_Added()
+    {
+        var config = new OutputCacheConfig();
+        config.DefaultExpirationTimeSpan = TimeSpan.FromSeconds(1);
+        config.MaximumBodySize = 10;
+        config.SizeLimit = 20;
+        config.UseCaseSensitivePaths = true;
+        config.NamedPolicies.Add("test1", new NamedCacheConfig { Duration = TimeSpan.FromSeconds(5), ExcludeDefaultPolicy = true });
+        config.NamedPolicies.Add("test2", new NamedCacheConfig { Duration = TimeSpan.FromSeconds(15), ExcludeDefaultPolicy = false });
+        config.NamedPolicies.Add("test3", new NamedCacheConfig { Duration = TimeSpan.FromSeconds(3), ExcludeDefaultPolicy = true, VaryByHeaders = new[] { "X-SomeHeader" } });
+
+        var builder = WebApplication.CreateBuilder();
+        builder.Services.AddOutputCache(config)
+                        .AddReverseProxy();
+
+        var app = builder.Build();
+
+        var policies = app.Services.GetRequiredService<IYarpOutputCachePolicyProvider>();
+        var test1 = await policies.GetPolicyAsync("test1");
+        var test2 = await policies.GetPolicyAsync("test2");
+        var test3 = await policies.GetPolicyAsync("test3");
+
+        Assert.NotNull(test1);
+        Assert.NotNull(test2);
+        Assert.NotNull(test3);
+    }
+
+    [Fact]
+    public async Task All_Options_Added_Json()
+    {
+        var json =
+            """
+            {
+                "OutputCache": {
+                    "DefaultExpirationTimeSpan": "00:05:00",
+                    "MaximumBodySize": 10,
+                    "SizeLimit": 20,
+                    "UseCaseSensitivePaths": true,
+                    "NamedPolicies": {
+                        "test1": {
+                            "Duration": "00:05:00",
+                            "ExcludeDefaultPolicy": true
+                        },
+                        "test2": {
+                            "Duration": "00:15:00",
+                            "ExcludeDefaultPolicy": false
+                        },
+                        "test3": {
+                            "Duration": "00:03:00",
+                            "ExcludeDefaultPolicy": true,
+                            "VaryByHeaders": [ "X-SomeHeader" ]
+                        }
+                    }
+                }
+            }
+            """;
+        var configBuilder = new ConfigurationBuilder();
+        var stream = new MemoryStream(Encoding.UTF8.GetBytes(json));
+        var config = configBuilder.AddJsonStream(stream).Build();
+
+        var builder = WebApplication.CreateBuilder();
+        builder.Services.AddOutputCache(config.GetSection("OutputCache"))
+                        .AddReverseProxy();
+
+        var app = builder.Build();
+
+        var policies = app.Services.GetRequiredService<IYarpOutputCachePolicyProvider>();
+        var test1 = await policies.GetPolicyAsync("test1");
+        var test2 = await policies.GetPolicyAsync("test2");
+        var test3 = await policies.GetPolicyAsync("test3");
+
+        Assert.NotNull(test1);
+        Assert.NotNull(test2);
+        Assert.NotNull(test3);
+    }
+}


### PR DESCRIPTION
When using the YARP container, configuring middleware via dependency injection (DI) is not an option. This limitation makes it difficult to customize middleware behavior without modifying and rebuilding the container image.

In this PR, I added the possibility to configure output caching in the container configuration file.