### PR TITLE
Create dotnet.config for Microsoft.Testing.Platform

### DIFF
--- a/dotnet.config
+++ b/dotnet.config
@@ -1,0 +1,2 @@
+[dotnet.test.runner]
+name = "Microsoft.Testing.Platform"


### PR DESCRIPTION
Since the repo is already on .NET 10 SDK:

https://github.com/dotnet/yarp/blob/60e3f87a6af43acc687c18435378eeadcabd8f99/global.json#L3

It can use dotnet.config to use the new `dotnet test` implementation for MTP.