### PR TITLE
Enable deterministic builds

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -12,6 +12,7 @@
     <StrongNameKeyId>Microsoft</StrongNameKeyId>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
     <IncludeSymbols>true</IncludeSymbols>
+    <Deterministic>true</Deterministic>
   </PropertyGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
Passes the `-deterministic` flag to the compiler. Fixes a BinSkim alert.