### PR TITLE
Add a notice about ingress annotations that affect cluster level options

### DIFF
--- a/samples/KubernetesIngress.Sample/README.md
+++ b/samples/KubernetesIngress.Sample/README.md
@@ -93,17 +93,19 @@ The table below lists the available annotations.
 |yarp.ingress.kubernetes.io/output-cache-policy|string|
 |yarp.ingress.kubernetes.io/backend-protocol|string|
 |yarp.ingress.kubernetes.io/cors-policy|string|
-|yarp.ingress.kubernetes.io/health-check|[ActivateHealthCheckConfig](https://learn.microsoft.com/dotnet/api/yarp.reverseproxy.configuration.activehealthcheckconfig)|
-|yarp.ingress.kubernetes.io/http-client|[HttpClientConfig](https://learn.microsoft.com/dotnet/api/yarp.reverseproxy.configuration.httpclientconfig)|
-|yarp.ingress.kubernetes.io/http-request|[ForwarderRequestConfig](https://learn.microsoft.com/en-us/dotnet/api/yarp.reverseproxy.forwarder.forwarderrequestconfig)|
-|yarp.ingress.kubernetes.io/load-balancing|string|
+|yarp.ingress.kubernetes.io/health-check|[ActivateHealthCheckConfig](https://learn.microsoft.com/dotnet/api/yarp.reverseproxy.configuration.activehealthcheckconfig) [^1]|
+|yarp.ingress.kubernetes.io/http-client|[HttpClientConfig](https://learn.microsoft.com/dotnet/api/yarp.reverseproxy.configuration.httpclientconfig) [^1]|
+|yarp.ingress.kubernetes.io/http-request|[ForwarderRequestConfig](https://learn.microsoft.com/en-us/dotnet/api/yarp.reverseproxy.forwarder.forwarderrequestconfig) [^1]|
+|yarp.ingress.kubernetes.io/load-balancing|string [^1]|
 |yarp.ingress.kubernetes.io/route-metadata|Dictionary&lt;string, string&gt;|
-|yarp.ingress.kubernetes.io/session-affinity|[SessionAffinityConfig](https://learn.microsoft.com/dotnet/api/yarp.reverseproxy.configuration.sessionaffinityconfig)|
+|yarp.ingress.kubernetes.io/session-affinity|[SessionAffinityConfig](https://learn.microsoft.com/dotnet/api/yarp.reverseproxy.configuration.sessionaffinityconfig) [^1]|
 |yarp.ingress.kubernetes.io/transforms|List&lt;Dictionary&lt;string, string&gt;&gt;|
 |yarp.ingress.kubernetes.io/route-headers|List&lt;[RouteHeader](https://learn.microsoft.com/dotnet/api/yarp.reverseproxy.configuration.routeheader)&gt;|
 |yarp.ingress.kubernetes.io/route-queryparameters|List&lt;[RouteQueryParameter](https://learn.microsoft.com/dotnet/api/yarp.reverseproxy.configuration.routequeryparameter)&gt;|
 |yarp.ingress.kubernetes.io/route-order|int|
 |yarp.ingress.kubernetes.io/route-methods|List&lt;string&gt;|
+
+[^1]: **Cluster-level annotation.** These annotations configure the YARP cluster, not the route. A cluster is identified by backend service name, namespace, and port. Multiple ingress rules targeting the same backend share the cluster, so conflicting values result in non-deterministic behavior. Ensure consistent values across all ingress rules for the same backend.
 
 #### Authorization Policy
 

--- a/samples/KubernetesIngress.Sample/README.md
+++ b/samples/KubernetesIngress.Sample/README.md
@@ -93,12 +93,12 @@ The table below lists the available annotations.
 |yarp.ingress.kubernetes.io/output-cache-policy|string|
 |yarp.ingress.kubernetes.io/backend-protocol|string|
 |yarp.ingress.kubernetes.io/cors-policy|string|
-|yarp.ingress.kubernetes.io/health-check|[ActivateHealthCheckConfig](https://learn.microsoft.com/dotnet/api/yarp.reverseproxy.configuration.activehealthcheckconfig) [\*](#cluster-level-annotations)|
-|yarp.ingress.kubernetes.io/http-client|[HttpClientConfig](https://learn.microsoft.com/dotnet/api/yarp.reverseproxy.configuration.httpclientconfig) [\*](#cluster-level-annotations)|
-|yarp.ingress.kubernetes.io/http-request|[ForwarderRequestConfig](https://learn.microsoft.com/en-us/dotnet/api/yarp.reverseproxy.forwarder.forwarderrequestconfig) [\*](#cluster-level-annotations)|
-|yarp.ingress.kubernetes.io/load-balancing|string [\*](#cluster-level-annotations)|
+|yarp.ingress.kubernetes.io/health-check [\*](#cluster-level-annotations)|[ActivateHealthCheckConfig](https://learn.microsoft.com/dotnet/api/yarp.reverseproxy.configuration.activehealthcheckconfig)|
+|yarp.ingress.kubernetes.io/http-client [\*](#cluster-level-annotations)|[HttpClientConfig](https://learn.microsoft.com/dotnet/api/yarp.reverseproxy.configuration.httpclientconfig)|
+|yarp.ingress.kubernetes.io/http-request [\*](#cluster-level-annotations)|[ForwarderRequestConfig](https://learn.microsoft.com/en-us/dotnet/api/yarp.reverseproxy.forwarder.forwarderrequestconfig)|
+|yarp.ingress.kubernetes.io/load-balancing [\*](#cluster-level-annotations)|string|
 |yarp.ingress.kubernetes.io/route-metadata|Dictionary&lt;string, string&gt;|
-|yarp.ingress.kubernetes.io/session-affinity|[SessionAffinityConfig](https://learn.microsoft.com/dotnet/api/yarp.reverseproxy.configuration.sessionaffinityconfig) [\*](#cluster-level-annotations)|
+|yarp.ingress.kubernetes.io/session-affinity [\*](#cluster-level-annotations)|[SessionAffinityConfig](https://learn.microsoft.com/dotnet/api/yarp.reverseproxy.configuration.sessionaffinityconfig)|
 |yarp.ingress.kubernetes.io/transforms|List&lt;Dictionary&lt;string, string&gt;&gt;|
 |yarp.ingress.kubernetes.io/route-headers|List&lt;[RouteHeader](https://learn.microsoft.com/dotnet/api/yarp.reverseproxy.configuration.routeheader)&gt;|
 |yarp.ingress.kubernetes.io/route-queryparameters|List&lt;[RouteQueryParameter](https://learn.microsoft.com/dotnet/api/yarp.reverseproxy.configuration.routequeryparameter)&gt;|

--- a/samples/KubernetesIngress.Sample/README.md
+++ b/samples/KubernetesIngress.Sample/README.md
@@ -105,10 +105,10 @@ The table below lists the available annotations.
 |yarp.ingress.kubernetes.io/route-order|int|
 |yarp.ingress.kubernetes.io/route-methods|List&lt;string&gt;|
 
-<a id="cluster-level-annotations"></a>
+#### Cluster-level annotations
 
 > [!NOTE]
-> **\* Cluster-level annotations:** These annotations configure the YARP cluster, not the route. A cluster is identified by backend service name, namespace, and port. Multiple ingress rules targeting the same backend share the cluster, so conflicting values result in non-deterministic behavior. Ensure consistent values across all ingress rules for the same backend.
+> Annotations marked with **\*** configure the YARP cluster, not the route. A cluster is identified by backend service name, namespace, and port. Multiple ingress rules targeting the same backend share the cluster, so conflicting values result in non-deterministic behavior. Ensure consistent values across all ingress rules for the same backend.
 
 #### Authorization Policy
 

--- a/samples/KubernetesIngress.Sample/README.md
+++ b/samples/KubernetesIngress.Sample/README.md
@@ -93,19 +93,22 @@ The table below lists the available annotations.
 |yarp.ingress.kubernetes.io/output-cache-policy|string|
 |yarp.ingress.kubernetes.io/backend-protocol|string|
 |yarp.ingress.kubernetes.io/cors-policy|string|
-|yarp.ingress.kubernetes.io/health-check|[ActivateHealthCheckConfig](https://learn.microsoft.com/dotnet/api/yarp.reverseproxy.configuration.activehealthcheckconfig) [^1]|
-|yarp.ingress.kubernetes.io/http-client|[HttpClientConfig](https://learn.microsoft.com/dotnet/api/yarp.reverseproxy.configuration.httpclientconfig) [^1]|
-|yarp.ingress.kubernetes.io/http-request|[ForwarderRequestConfig](https://learn.microsoft.com/en-us/dotnet/api/yarp.reverseproxy.forwarder.forwarderrequestconfig) [^1]|
-|yarp.ingress.kubernetes.io/load-balancing|string [^1]|
+|yarp.ingress.kubernetes.io/health-check|[ActivateHealthCheckConfig](https://learn.microsoft.com/dotnet/api/yarp.reverseproxy.configuration.activehealthcheckconfig) [\*](#cluster-level-annotations)|
+|yarp.ingress.kubernetes.io/http-client|[HttpClientConfig](https://learn.microsoft.com/dotnet/api/yarp.reverseproxy.configuration.httpclientconfig) [\*](#cluster-level-annotations)|
+|yarp.ingress.kubernetes.io/http-request|[ForwarderRequestConfig](https://learn.microsoft.com/en-us/dotnet/api/yarp.reverseproxy.forwarder.forwarderrequestconfig) [\*](#cluster-level-annotations)|
+|yarp.ingress.kubernetes.io/load-balancing|string [\*](#cluster-level-annotations)|
 |yarp.ingress.kubernetes.io/route-metadata|Dictionary&lt;string, string&gt;|
-|yarp.ingress.kubernetes.io/session-affinity|[SessionAffinityConfig](https://learn.microsoft.com/dotnet/api/yarp.reverseproxy.configuration.sessionaffinityconfig) [^1]|
+|yarp.ingress.kubernetes.io/session-affinity|[SessionAffinityConfig](https://learn.microsoft.com/dotnet/api/yarp.reverseproxy.configuration.sessionaffinityconfig) [\*](#cluster-level-annotations)|
 |yarp.ingress.kubernetes.io/transforms|List&lt;Dictionary&lt;string, string&gt;&gt;|
 |yarp.ingress.kubernetes.io/route-headers|List&lt;[RouteHeader](https://learn.microsoft.com/dotnet/api/yarp.reverseproxy.configuration.routeheader)&gt;|
 |yarp.ingress.kubernetes.io/route-queryparameters|List&lt;[RouteQueryParameter](https://learn.microsoft.com/dotnet/api/yarp.reverseproxy.configuration.routequeryparameter)&gt;|
 |yarp.ingress.kubernetes.io/route-order|int|
 |yarp.ingress.kubernetes.io/route-methods|List&lt;string&gt;|
 
-[^1]: **Cluster-level annotation.** These annotations configure the YARP cluster, not the route. A cluster is identified by backend service name, namespace, and port. Multiple ingress rules targeting the same backend share the cluster, so conflicting values result in non-deterministic behavior. Ensure consistent values across all ingress rules for the same backend.
+<a id="cluster-level-annotations"></a>
+
+> [!NOTE]
+> **\* Cluster-level annotations:** These annotations configure the YARP cluster, not the route. A cluster is identified by backend service name, namespace, and port. Multiple ingress rules targeting the same backend share the cluster, so conflicting values result in non-deterministic behavior. Ensure consistent values across all ingress rules for the same backend.
 
 #### Authorization Policy
 


### PR DESCRIPTION
Update docs to include a notice on ingress annotations that affect cluster level options and can conflict between multiple ingresses.