### PR TITLE
Use `WatchListXXXForAllNamespacesAsync` to list Kubernetes resources and refactor `WatchAsync`

### DIFF
--- a/src/Kubernetes.Controller/Client/ResourceInformer.cs
+++ b/src/Kubernetes.Controller/Client/ResourceInformer.cs
@@ -283,7 +283,7 @@ public abstract class ResourceInformer<TResource, TListResource> : BackgroundHos
     }
 
     // Encapsulate LastEventUtcTicks into a class to eliminate IDE warning `Captured variable is modified in the outer scope`.
-    private record WatchState
+    private class WatchState
     {
         public long LastEventUtcTicks =  DateTime.UtcNow.Ticks;
     }
@@ -296,7 +296,7 @@ public abstract class ResourceInformer<TResource, TListResource> : BackgroundHos
             typeof(TResource).Name,
             _lastResourceVersion);
 
-        var linkedCancellationTokenSource = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        using var linkedCancellationTokenSource = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
 
         var watchState =  new WatchState();
         // reconnect if no events have arrived after a certain time
@@ -312,7 +312,14 @@ public abstract class ResourceInformer<TResource, TListResource> : BackgroundHos
                         EventId(EventType.DisposingToReconnect),
                         "Disposing watcher for {ResourceType} to cause reconnect.",
                         typeof(TResource).Name);
-                    linkedCancellationTokenSource.Cancel();
+                    try
+                    {
+                        linkedCancellationTokenSource.Cancel();
+                    }
+                    catch (ObjectDisposedException)
+                    {
+                        // The outer scope has already disposed of the cancellation token source.
+                    }
                 }
             },
             state: null,

--- a/src/Kubernetes.Controller/Client/ResourceInformer.cs
+++ b/src/Kubernetes.Controller/Client/ResourceInformer.cs
@@ -197,7 +197,7 @@ public abstract class ResourceInformer<TResource, TListResource> : BackgroundHos
     }
 
     protected abstract Task<HttpOperationResponse<TListResource>> RetrieveResourceListAsync(string resourceVersion = null, ResourceSelector<TResource> resourceSelector = null, CancellationToken cancellationToken = default);
-    protected abstract Watcher<TResource> WatchResourceListAsync(string resourceVersion = null, ResourceSelector<TResource> resourceSelector = null, Action<WatchEventType, TResource> onEvent = null, Action<Exception> onError = null, Action onClosed = null);
+    protected abstract IAsyncEnumerable<(WatchEventType, TResource)> WatchResourceListAsync(string resourceVersion = null, ResourceSelector<TResource> resourceSelector = null, Action<Exception> onError = null);
 
     private static EventId EventId(EventType eventType) => new EventId((int)eventType, eventType.ToString());
 
@@ -282,6 +282,12 @@ public abstract class ResourceInformer<TResource, TListResource> : BackgroundHos
             typeof(TResource).Name);
     }
 
+    // Encapsulate LastEventUtcTicks into a class to eliminate IDE warning `Captured variable is modified in the outer scope`.
+    private record WatchState
+    {
+        public long LastEventUtcTicks =  DateTime.UtcNow.Ticks;
+    }
+
     private async Task WatchAsync(CancellationToken cancellationToken)
     {
         Logger.LogInformation(
@@ -290,75 +296,62 @@ public abstract class ResourceInformer<TResource, TListResource> : BackgroundHos
             typeof(TResource).Name,
             _lastResourceVersion);
 
-        // completion source helps turn OnClose callback into something awaitable
-        var watcherCompletionSource = new TaskCompletionSource<int>();
+        var linkedCancellationTokenSource = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
 
-        // begin watching where list left off
-        var watcher = WatchResourceListAsync(resourceVersion: _lastResourceVersion, resourceSelector: _selector,
-            (watchEventType, item) =>
-            {
-                if (!watcherCompletionSource.Task.IsCompleted)
-                {
-                    OnEvent(watchEventType, item);
-                }
-            },
-            error =>
-            {
-                if (error is KubernetesException kubernetesError)
-                {
-                    // deal with this non-recoverable condition "too old resource version"
-                    if (string.Equals(kubernetesError.Status.Reason, "Expired", StringComparison.Ordinal))
-                    {
-                        // cause this error to surface
-                        watcherCompletionSource.TrySetException(error);
-                        throw error;
-                    }
-                }
-
-                Logger.LogDebug(
-                    EventId(EventType.IgnoringError),
-                    "Ignoring error {ErrorType}: {ErrorMessage}",
-                    error.GetType().Name,
-                    error.Message);
-            },
-            () =>
-            {
-                watcherCompletionSource.TrySetResult(0);
-            }
-        );
-
-        var lastEventUtc = DateTime.UtcNow;
-
+        var watchState =  new WatchState();
         // reconnect if no events have arrived after a certain time
-        using var checkLastEventUtcTimer = new Timer(
+        await using var checkLastEventUtcTimer = new Timer(
             _ =>
             {
-                var lastEvent = DateTime.UtcNow - lastEventUtc;
-                if (lastEvent > TimeSpan.FromMinutes(9.5))
+                var currentTicks = Interlocked.Read(ref watchState.LastEventUtcTicks);
+                var timeSinceLastEvent = TimeSpan.FromTicks(DateTime.UtcNow.Ticks - currentTicks);
+                if (timeSinceLastEvent > TimeSpan.FromMinutes(9.5))
                 {
-                    lastEventUtc = DateTime.MaxValue;
+                    Interlocked.Exchange(ref watchState.LastEventUtcTicks, DateTime.MaxValue.Ticks);
                     Logger.LogDebug(
                         EventId(EventType.DisposingToReconnect),
                         "Disposing watcher for {ResourceType} to cause reconnect.",
                         typeof(TResource).Name);
-
-                    watcherCompletionSource.TrySetCanceled();
-                    watcher.Dispose();
-
+                    linkedCancellationTokenSource.Cancel();
                 }
             },
             state: null,
             dueTime: TimeSpan.FromSeconds(45),
             period: TimeSpan.FromSeconds(45));
 
-        using var registration = cancellationToken.Register(watcher.Dispose);
         try
         {
-            await watcherCompletionSource.Task;
+            await foreach (var (watchEventType, item) in WatchResourceListAsync(resourceVersion: _lastResourceVersion,
+                                   resourceSelector: _selector, onError: OnError)
+                               .WithCancellation(linkedCancellationTokenSource.Token))
+            {
+                Interlocked.Exchange(ref watchState.LastEventUtcTicks, DateTime.UtcNow.Ticks);
+                OnEvent(watchEventType, item);
+            }
         }
-        catch (TaskCanceledException)
+        catch (OperationCanceledException)
         {
+            // The loop was canceled safely, either by the timer or the original cancellationToken
         }
+    }
+
+    private void OnError(Exception error)
+    {
+        if (error is KubernetesException kubernetesError)
+        {
+            // deal with this non-recoverable condition "too old resource version"
+            if (string.Equals(kubernetesError.Status.Reason, "Expired", StringComparison.Ordinal))
+            {
+                // cause this error to surface
+                throw error;
+            }
+        }
+
+        Logger.LogDebug(
+            EventId(EventType.IgnoringError),
+            "Ignoring error {ErrorType}: {ErrorMessage}",
+            error.GetType().Name,
+            error.Message);
     }
 
     private void OnEvent(WatchEventType watchEventType, TResource item)

--- a/src/Kubernetes.Controller/Client/ResourceInformer.cs
+++ b/src/Kubernetes.Controller/Client/ResourceInformer.cs
@@ -288,11 +288,6 @@ public abstract class ResourceInformer<TResource, TListResource> : BackgroundHos
         // Stopwatch timestamp of the most recent watch event.
         // Access only through Interlocked operations.
         public long LastEventStopwatchTimestamp = Stopwatch.GetTimestamp();
-
-        // Used as an atomic boolean to ensure the re-connect cancellation path is triggered only once.
-        // 0 means cancellation has not been requested; 1 means cancellation has already been requested.
-        // Access only through Interlocked operations.
-        public int CancellationRequested;
     }
 
     private async Task WatchAsync(CancellationToken cancellationToken)
@@ -312,8 +307,7 @@ public abstract class ResourceInformer<TResource, TListResource> : BackgroundHos
             _ =>
             {
                 var lastEventTimestamp = Interlocked.Read(ref watchState.LastEventStopwatchTimestamp);
-                if (Stopwatch.GetElapsedTime(lastEventTimestamp) > TimeSpan.FromMinutes(9.5) &&
-                    Interlocked.Exchange(ref watchState.CancellationRequested, 1) == 0)
+                if (Stopwatch.GetElapsedTime(lastEventTimestamp) > TimeSpan.FromMinutes(9.5))
                 {
                     Logger.LogDebug(
                         EventId(EventType.DisposingToReconnect),

--- a/src/Kubernetes.Controller/Client/ResourceInformer.cs
+++ b/src/Kubernetes.Controller/Client/ResourceInformer.cs
@@ -328,9 +328,8 @@ public abstract class ResourceInformer<TResource, TListResource> : BackgroundHos
 
         try
         {
-            await foreach (var (watchEventType, item) in WatchResourceListAsync(resourceVersion: _lastResourceVersion,
-                                   resourceSelector: _selector, onError: OnError)
-                               .WithCancellation(linkedCancellationTokenSource.Token))
+            await foreach (var (watchEventType, item) in WatchResourceListAsync(_lastResourceVersion, _selector, OnError)
+                .WithCancellation(linkedCancellationTokenSource.Token))
             {
                 Interlocked.Exchange(ref watchState.LastEventUtcTicks, DateTime.UtcNow.Ticks);
                 OnEvent(watchEventType, item);

--- a/src/Kubernetes.Controller/Client/ResourceInformer.cs
+++ b/src/Kubernetes.Controller/Client/ResourceInformer.cs
@@ -307,7 +307,7 @@ public abstract class ResourceInformer<TResource, TListResource> : BackgroundHos
 
         var watchState = new WatchState();
 
-        // reconnect if no events have arrived after a certain time
+        // reconnect if no events have arrived after a certain time.
         await using var watchdogTimer = new Timer(
             _ =>
             {
@@ -344,7 +344,7 @@ public abstract class ResourceInformer<TResource, TListResource> : BackgroundHos
         }
         catch (OperationCanceledException)
         {
-            // The loop was canceled safely, either by the timer or the original cancellationToken
+            // The loop was canceled safely, either by the timer or the original cancellationToken.
         }
     }
 

--- a/src/Kubernetes.Controller/Client/ResourceInformer.cs
+++ b/src/Kubernetes.Controller/Client/ResourceInformer.cs
@@ -283,7 +283,7 @@ public abstract class ResourceInformer<TResource, TListResource> : BackgroundHos
     }
 
     // Encapsulate LastEventUtcTicks into a class to eliminate IDE warning `Captured variable is modified in the outer scope`.
-    private class WatchState
+    private sealed class WatchState
     {
         public long LastEventUtcTicks =  DateTime.UtcNow.Ticks;
     }

--- a/src/Kubernetes.Controller/Client/ResourceInformer.cs
+++ b/src/Kubernetes.Controller/Client/ResourceInformer.cs
@@ -283,7 +283,7 @@ public abstract class ResourceInformer<TResource, TListResource> : BackgroundHos
             typeof(TResource).Name);
     }
 
-    private class WatchState
+    private sealed class WatchState
     {
         // Stopwatch timestamp of the most recent watch event.
         // Access only through Interlocked operations.

--- a/src/Kubernetes.Controller/Client/ResourceInformer.cs
+++ b/src/Kubernetes.Controller/Client/ResourceInformer.cs
@@ -311,8 +311,8 @@ public abstract class ResourceInformer<TResource, TListResource> : BackgroundHos
         await using var watchdogTimer = new Timer(
             _ =>
             {
-                var currentTimestamp = Interlocked.Read(ref watchState.LastEventStopwatchTimestamp);
-                if (Stopwatch.GetElapsedTime(currentTimestamp) > TimeSpan.FromMinutes(9.5) &&
+                var lastEventTimestamp = Interlocked.Read(ref watchState.LastEventStopwatchTimestamp);
+                if (Stopwatch.GetElapsedTime(lastEventTimestamp) > TimeSpan.FromMinutes(9.5) &&
                     Interlocked.Exchange(ref watchState.CancellationRequested, 1) == 0)
                 {
                     Logger.LogDebug(

--- a/src/Kubernetes.Controller/Client/ResourceInformer.cs
+++ b/src/Kubernetes.Controller/Client/ResourceInformer.cs
@@ -347,7 +347,7 @@ public abstract class ResourceInformer<TResource, TListResource> : BackgroundHos
         if (error is KubernetesException kubernetesError)
         {
             // deal with this non-recoverable condition "too old resource version"
-            if (string.Equals(kubernetesError.Status.Reason, "Expired", StringComparison.Ordinal))
+            if (kubernetesError.Status.Reason == "Expired")
             {
                 // cause this error to surface
                 throw error;

--- a/src/Kubernetes.Controller/Client/ResourceInformer.cs
+++ b/src/Kubernetes.Controller/Client/ResourceInformer.cs
@@ -302,7 +302,7 @@ public abstract class ResourceInformer<TResource, TListResource> : BackgroundHos
 
         var watchState = new WatchState();
 
-        // reconnect if no events have arrived after a certain time.
+        // Reconnect if no events have arrived after a certain time.
         await using var watchdogTimer = new Timer(
             _ =>
             {
@@ -319,7 +319,7 @@ public abstract class ResourceInformer<TResource, TListResource> : BackgroundHos
                     }
                     catch (ObjectDisposedException)
                     {
-                        // The outer scope has already disposed of the cancellation token source.
+                        // The token source was already disposed of, so cancellation is no longer needed.
                     }
                 }
             },
@@ -346,10 +346,10 @@ public abstract class ResourceInformer<TResource, TListResource> : BackgroundHos
     {
         if (error is KubernetesException kubernetesError)
         {
-            // deal with this non-recoverable condition "too old resource version"
+            // Deal with this non-recoverable condition "too old resource version".
             if (kubernetesError.Status.Reason == "Expired")
             {
-                // cause this error to surface
+                // Cause this error to surface.
                 throw error;
             }
         }

--- a/src/Kubernetes.Controller/Client/ResourceInformer.cs
+++ b/src/Kubernetes.Controller/Client/ResourceInformer.cs
@@ -9,6 +9,7 @@ using Microsoft.Extensions.Logging;
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.Diagnostics;
 using System.IO;
 using System.Net.Sockets;
 using System.Threading;
@@ -282,10 +283,16 @@ public abstract class ResourceInformer<TResource, TListResource> : BackgroundHos
             typeof(TResource).Name);
     }
 
-    // Encapsulate LastEventUtcTicks into a class to eliminate IDE warning `Captured variable is modified in the outer scope`.
     private class WatchState
     {
-        public long LastEventUtcTicks =  DateTime.UtcNow.Ticks;
+        // Stopwatch timestamp of the most recent watch event.
+        // Access only through Interlocked operations.
+        public long LastEventStopwatchTimestamp = Stopwatch.GetTimestamp();
+
+        // Used as an atomic boolean to ensure the re-connect cancellation path is triggered only once.
+        // 0 means cancellation has not been requested; 1 means cancellation has already been requested.
+        // Access only through Interlocked operations.
+        public int CancellationRequested;
     }
 
     private async Task WatchAsync(CancellationToken cancellationToken)
@@ -298,16 +305,16 @@ public abstract class ResourceInformer<TResource, TListResource> : BackgroundHos
 
         using var linkedCancellationTokenSource = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
 
-        var watchState =  new WatchState();
+        var watchState = new WatchState();
+
         // reconnect if no events have arrived after a certain time
-        await using var checkLastEventUtcTimer = new Timer(
+        await using var watchdogTimer = new Timer(
             _ =>
             {
-                var currentTicks = Interlocked.Read(ref watchState.LastEventUtcTicks);
-                var timeSinceLastEvent = TimeSpan.FromTicks(DateTime.UtcNow.Ticks - currentTicks);
-                if (timeSinceLastEvent > TimeSpan.FromMinutes(9.5))
+                var currentTimestamp = Interlocked.Read(ref watchState.LastEventStopwatchTimestamp);
+                if (Stopwatch.GetElapsedTime(currentTimestamp) > TimeSpan.FromMinutes(9.5) &&
+                    Interlocked.Exchange(ref watchState.CancellationRequested, 1) == 0)
                 {
-                    Interlocked.Exchange(ref watchState.LastEventUtcTicks, DateTime.MaxValue.Ticks);
                     Logger.LogDebug(
                         EventId(EventType.DisposingToReconnect),
                         "Disposing watcher for {ResourceType} to cause reconnect.",
@@ -331,7 +338,7 @@ public abstract class ResourceInformer<TResource, TListResource> : BackgroundHos
             await foreach (var (watchEventType, item) in WatchResourceListAsync(_lastResourceVersion, _selector, OnError)
                 .WithCancellation(linkedCancellationTokenSource.Token))
             {
-                Interlocked.Exchange(ref watchState.LastEventUtcTicks, DateTime.UtcNow.Ticks);
+                Interlocked.Exchange(ref watchState.LastEventStopwatchTimestamp, Stopwatch.GetTimestamp());
                 OnEvent(watchEventType, item);
             }
         }

--- a/src/Kubernetes.Controller/Client/V1EndpointsResourceInformer.cs
+++ b/src/Kubernetes.Controller/Client/V1EndpointsResourceInformer.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
+using System.Collections.Generic;
 using k8s;
 using k8s.Autorest;
 using k8s.Models;
@@ -28,8 +29,9 @@ internal class V1EndpointsResourceInformer : ResourceInformer<V1Endpoints, V1End
         return Client.CoreV1.ListEndpointsForAllNamespacesWithHttpMessagesAsync(resourceVersion: resourceVersion, fieldSelector: resourceSelector?.FieldSelector, cancellationToken: cancellationToken);
     }
 
-    protected override Watcher<V1Endpoints> WatchResourceListAsync(string resourceVersion = null, ResourceSelector<V1Endpoints> resourceSelector = null, Action<WatchEventType, V1Endpoints> onEvent = null, Action<Exception> onError = null, Action onClosed = null)
+    protected override IAsyncEnumerable<(WatchEventType, V1Endpoints)> WatchResourceListAsync(string resourceVersion = null, ResourceSelector<V1Endpoints> resourceSelector = null,
+        Action<Exception> onError = null)
     {
-        return Client.CoreV1.WatchListEndpointsForAllNamespaces(resourceVersion: resourceVersion, fieldSelector: resourceSelector?.FieldSelector, onEvent: onEvent, onError: onError, onClosed: onClosed);
+        return Client.CoreV1.WatchListEndpointsForAllNamespacesAsync(resourceVersion: resourceVersion, fieldSelector: resourceSelector?.FieldSelector, onError: onError);
     }
 }

--- a/src/Kubernetes.Controller/Client/V1IngressClassResourceInformer.cs
+++ b/src/Kubernetes.Controller/Client/V1IngressClassResourceInformer.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
+using System.Collections.Generic;
 using k8s;
 using k8s.Autorest;
 using k8s.Models;
@@ -28,8 +29,9 @@ internal class V1IngressClassResourceInformer : ResourceInformer<V1IngressClass,
         return Client.NetworkingV1.ListIngressClassWithHttpMessagesAsync(resourceVersion: resourceVersion, fieldSelector: resourceSelector?.FieldSelector, cancellationToken: cancellationToken);
     }
 
-    protected override Watcher<V1IngressClass> WatchResourceListAsync(string resourceVersion = null, ResourceSelector<V1IngressClass> resourceSelector = null, Action<WatchEventType, V1IngressClass> onEvent = null, Action<Exception> onError = null, Action onClosed = null)
+    protected override IAsyncEnumerable<(WatchEventType, V1IngressClass)> WatchResourceListAsync(string resourceVersion = null, ResourceSelector<V1IngressClass> resourceSelector = null,
+        Action<Exception> onError = null)
     {
-        return Client.NetworkingV1.WatchListIngressClass(resourceVersion: resourceVersion, fieldSelector: resourceSelector?.FieldSelector, onEvent: onEvent, onError: onError, onClosed: onClosed);
+        return Client.NetworkingV1.WatchListIngressClassAsync(resourceVersion: resourceVersion, fieldSelector: resourceSelector?.FieldSelector, onError: onError);
     }
 }

--- a/src/Kubernetes.Controller/Client/V1IngressResourceInformer.cs
+++ b/src/Kubernetes.Controller/Client/V1IngressResourceInformer.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
+using System.Collections.Generic;
 using k8s;
 using k8s.Autorest;
 using k8s.Models;
@@ -28,9 +29,9 @@ internal class V1IngressResourceInformer : ResourceInformer<V1Ingress, V1Ingress
         return Client.NetworkingV1.ListIngressForAllNamespacesWithHttpMessagesAsync(resourceVersion: resourceVersion, fieldSelector: resourceSelector?.FieldSelector, cancellationToken: cancellationToken);
     }
 
-    protected override Watcher<V1Ingress> WatchResourceListAsync(string resourceVersion = null, ResourceSelector<V1Ingress> resourceSelector = null, Action<WatchEventType, V1Ingress> onEvent = null, Action<Exception> onError = null, Action onClosed = null)
+    protected override IAsyncEnumerable<(WatchEventType, V1Ingress)> WatchResourceListAsync(string resourceVersion = null, ResourceSelector<V1Ingress> resourceSelector = null, Action<Exception> onError = null)
     {
-        return Client.NetworkingV1.WatchListIngressForAllNamespaces(resourceVersion: resourceVersion,
-            fieldSelector: resourceSelector?.FieldSelector, onEvent: onEvent, onError: onError, onClosed: onClosed);
+        return Client.NetworkingV1.WatchListIngressForAllNamespacesAsync();
     }
+
 }

--- a/src/Kubernetes.Controller/Client/V1IngressResourceInformer.cs
+++ b/src/Kubernetes.Controller/Client/V1IngressResourceInformer.cs
@@ -31,7 +31,7 @@ internal class V1IngressResourceInformer : ResourceInformer<V1Ingress, V1Ingress
 
     protected override IAsyncEnumerable<(WatchEventType, V1Ingress)> WatchResourceListAsync(string resourceVersion = null, ResourceSelector<V1Ingress> resourceSelector = null, Action<Exception> onError = null)
     {
-        return Client.NetworkingV1.WatchListIngressForAllNamespacesAsync();
+        return Client.NetworkingV1.WatchListIngressForAllNamespacesAsync(resourceVersion: resourceVersion, fieldSelector: resourceSelector?.FieldSelector, onError: onError);
     }
 
 }

--- a/src/Kubernetes.Controller/Client/V1SecretResourceInformer.cs
+++ b/src/Kubernetes.Controller/Client/V1SecretResourceInformer.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
+using System.Collections.Generic;
 using k8s;
 using k8s.Autorest;
 using k8s.Models;
@@ -28,8 +29,9 @@ internal class V1SecretResourceInformer : ResourceInformer<V1Secret, V1SecretLis
         return Client.CoreV1.ListSecretForAllNamespacesWithHttpMessagesAsync(resourceVersion: resourceVersion, fieldSelector: resourceSelector?.FieldSelector, cancellationToken: cancellationToken);
     }
 
-    protected override Watcher<V1Secret> WatchResourceListAsync(string resourceVersion = null, ResourceSelector<V1Secret> resourceSelector = null, Action<WatchEventType, V1Secret> onEvent = null, Action<Exception> onError = null, Action onClosed = null)
+    protected override IAsyncEnumerable<(WatchEventType, V1Secret)> WatchResourceListAsync(string resourceVersion = null, ResourceSelector<V1Secret> resourceSelector = null,
+        Action<Exception> onError = null)
     {
-        return Client.CoreV1.WatchListSecretForAllNamespaces(resourceVersion: resourceVersion, fieldSelector: resourceSelector?.FieldSelector, onEvent: onEvent, onError: onError, onClosed: onClosed);
+        return Client.CoreV1.WatchListSecretForAllNamespacesAsync(resourceVersion: resourceVersion, fieldSelector: resourceSelector?.FieldSelector, onError: onError);
     }
 }

--- a/src/Kubernetes.Controller/Client/V1ServiceResourceInformer.cs
+++ b/src/Kubernetes.Controller/Client/V1ServiceResourceInformer.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
+using System.Collections.Generic;
 using k8s;
 using k8s.Autorest;
 using k8s.Models;
@@ -28,8 +29,9 @@ internal class V1ServiceResourceInformer : ResourceInformer<V1Service, V1Service
         return Client.CoreV1.ListServiceForAllNamespacesWithHttpMessagesAsync(resourceVersion: resourceVersion, fieldSelector: resourceSelector?.FieldSelector, cancellationToken: cancellationToken);
     }
 
-    protected override Watcher<V1Service> WatchResourceListAsync(string resourceVersion = null, ResourceSelector<V1Service> resourceSelector = null, Action<WatchEventType, V1Service> onEvent = null, Action<Exception> onError = null, Action onClosed = null)
+    protected override IAsyncEnumerable<(WatchEventType, V1Service)> WatchResourceListAsync(string resourceVersion = null, ResourceSelector<V1Service> resourceSelector = null,
+        Action<Exception> onError = null)
     {
-        return Client.CoreV1.WatchListServiceForAllNamespaces(resourceVersion: resourceVersion, fieldSelector: resourceSelector?.FieldSelector, onEvent: onEvent, onError: onError, onClosed: onClosed);
+        return Client.CoreV1.WatchListServiceForAllNamespacesAsync(resourceVersion: resourceVersion, fieldSelector: resourceSelector?.FieldSelector, onError: onError);
     }
 }

--- a/test/Kubernetes.Tests/Client/V1DeploymentResourceInformer.cs
+++ b/test/Kubernetes.Tests/Client/V1DeploymentResourceInformer.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
+using System.Collections.Generic;
 using k8s;
 using k8s.Autorest;
 using k8s.Models;
@@ -28,8 +29,9 @@ internal class V1DeploymentResourceInformer : ResourceInformer<V1Deployment, V1D
         return Client.AppsV1.ListDeploymentForAllNamespacesWithHttpMessagesAsync(resourceVersion: resourceVersion, fieldSelector: resourceSelector?.FieldSelector, cancellationToken: cancellationToken);
     }
 
-    protected override Watcher<V1Deployment> WatchResourceListAsync(string resourceVersion = null, ResourceSelector<V1Deployment> resourceSelector = null, Action<WatchEventType, V1Deployment> onEvent = null, Action<Exception> onError = null, Action onClosed = null)
+    protected override IAsyncEnumerable<(WatchEventType, V1Deployment)> WatchResourceListAsync(string resourceVersion = null, ResourceSelector<V1Deployment> resourceSelector = null,
+        Action<Exception> onError = null)
     {
-        return Client.AppsV1.WatchListDeploymentForAllNamespaces(resourceVersion: resourceVersion, fieldSelector: resourceSelector?.FieldSelector, onEvent: onEvent, onError: onError, onClosed: onClosed);
+        return Client.AppsV1.WatchListDeploymentForAllNamespacesAsync(resourceVersion: resourceVersion, fieldSelector: resourceSelector?.FieldSelector, onError: onError);
     }
 }

--- a/test/Kubernetes.Tests/Client/V1PodResourceInformer.cs
+++ b/test/Kubernetes.Tests/Client/V1PodResourceInformer.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
+using System.Collections.Generic;
 using k8s;
 using k8s.Autorest;
 using k8s.Models;
@@ -28,8 +29,9 @@ internal class V1PodResourceInformer : ResourceInformer<V1Pod, V1PodList>
         return Client.CoreV1.ListPodForAllNamespacesWithHttpMessagesAsync(resourceVersion: resourceVersion, fieldSelector: resourceSelector?.FieldSelector, cancellationToken: cancellationToken);
     }
 
-    protected override Watcher<V1Pod> WatchResourceListAsync(string resourceVersion = null, ResourceSelector<V1Pod> resourceSelector = null, Action<WatchEventType, V1Pod> onEvent = null, Action<Exception> onError = null, Action onClosed = null)
+    protected override IAsyncEnumerable<(WatchEventType, V1Pod)> WatchResourceListAsync(string resourceVersion = null, ResourceSelector<V1Pod> resourceSelector = null,
+        Action<Exception> onError = null)
     {
-        return Client.CoreV1.WatchListPodForAllNamespaces(resourceVersion: resourceVersion, fieldSelector: resourceSelector?.FieldSelector, onEvent: onEvent, onError: onError, onClosed: onClosed);
+        return Client.CoreV1.WatchListPodForAllNamespacesAsync(resourceVersion: resourceVersion, fieldSelector: resourceSelector?.FieldSelector, onError: onError);
     }
 }


### PR DESCRIPTION
This PR
1. Replace `WatchListXXXForAllNamespaces` with `WatchListXXXForAllNamespacesAsync`. For instace `WatchListEndpointsForAllNamespaces` with `WatchListEndpointsForAllNamespacesAsync`. If so, we could get watch results asynchrounously.
2. Refactor `WatchAsync` to handle returned `IAsyncEnumerable(<WatchEventType, TResource>)` in step 1. In this way we could remove `TaskCompletionSource` which simulates a Task and rely on `await foreach`.


Appreciate every feedback!

Closes #3008