### PR TITLE
Set proxy.forwarder activity DisplayName to request path

### DIFF
--- a/src/ReverseProxy/Model/ProxyPipelineInitializerMiddleware.cs
+++ b/src/ReverseProxy/Model/ProxyPipelineInitializerMiddleware.cs
@@ -63,6 +63,11 @@ internal sealed class ProxyPipelineInitializerMiddleware
 
         var activity = Observability.YarpActivitySource.CreateActivity("proxy.forwarder", ActivityKind.Server);
 
+        if (activity is not null && context.Request.Path.Value is { Length: > 0 } path)
+        {
+            activity.DisplayName = path;
+        }
+
         return activity is null
             ? _next(context)
             : AwaitWithActivity(context, activity);

--- a/test/ReverseProxy.Tests/Model/ProxyPipelineInitializerMiddlewareTests.cs
+++ b/test/ReverseProxy.Tests/Model/ProxyPipelineInitializerMiddlewareTests.cs
@@ -160,6 +160,43 @@ public class ProxyPipelineInitializerMiddlewareTests : TestAutoMockBase
         }
     }
 
+    [Fact]
+    public async Task Invoke_SetsActivityDisplayName_FromRequestPath()
+    {
+        var httpClient = new HttpMessageInvoker(new Mock<HttpMessageHandler>().Object);
+        var cluster1 = new ClusterState(clusterId: "cluster1");
+        cluster1.Model = new ClusterModel(new ClusterConfig(), httpClient);
+        var destination1 = cluster1.Destinations.GetOrAdd(
+            "destination1",
+            id => new DestinationState(id) { Model = new DestinationModel(new DestinationConfig { Address = "https://localhost:123/a/b/" }) });
+        cluster1.DestinationsState = new ClusterDestinationsState(new[] { destination1 }, new[] { destination1 });
+
+        var routeConfig = new RouteModel(
+            config: new RouteConfig(),
+            cluster1,
+            HttpTransformer.Default);
+        var aspNetCoreEndpoint = CreateAspNetCoreEndpoint(routeConfig);
+        var httpContext = new DefaultHttpContext();
+        httpContext.SetEndpoint(aspNetCoreEndpoint);
+        httpContext.Request.Path = "/api/users/42";
+
+        var capturedActivities = new List<Activity>();
+        using var listener = new ActivityListener
+        {
+            ShouldListenTo = source => source.Name == "Yarp.ReverseProxy",
+            Sample = (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllData,
+            ActivityStarted = activity => capturedActivities.Add(activity),
+        };
+        ActivitySource.AddActivityListener(listener);
+
+        var sut = Create<ProxyPipelineInitializerMiddleware>();
+
+        await sut.Invoke(httpContext);
+
+        var activity = Assert.Single(capturedActivities);
+        Assert.Equal("/api/users/42", activity.DisplayName);
+    }
+
     private static Endpoint CreateAspNetCoreEndpoint(RouteModel routeConfig, Action<RouteEndpointBuilder> configure = null)
     {
         var endpointBuilder = new RouteEndpointBuilder(


### PR DESCRIPTION
Fixes #2667.

The proxy.forwarder activity is created with a constant name, so every YARP request shows up under the same name in Aspire / OTel dashboards. This sets DisplayName to `Request.Path` so requests are distinguishable. `OperationName` stays `"proxy.forwarder"` so anything filtering by activity name isn't affected. Empty paths keep the default.

Added `Invoke_SetsActivityDisplayName_FromRequestPath` in `ProxyPipelineInitializerMiddlewareTests`. Verified it fails on main and passes with the change.

The issue is tagged Type: Documentation — let me know if you'd rather close this in favor of a docs-only fix instead.
