### PR TITLE
Avoid request transform context allocation

### DIFF
--- a/src/ReverseProxy/Transforms/Builder/StructuredTransformer.cs
+++ b/src/ReverseProxy/Transforms/Builder/StructuredTransformer.cs
@@ -18,6 +18,8 @@ namespace Yarp.ReverseProxy.Transforms.Builder;
 /// </summary>
 internal sealed class StructuredTransformer : HttpTransformer
 {
+    private readonly bool _canUseRequestTransformFastPath;
+
     /// <summary>
     /// Creates a new <see cref="StructuredTransformer"/> instance.
     /// </summary>
@@ -36,6 +38,7 @@ internal sealed class StructuredTransformer : HttpTransformer
         RequestTransforms = requestTransforms.ToArray();
         ResponseTransforms = responseTransforms.ToArray();
         ResponseTrailerTransforms = responseTrailerTransforms.ToArray();
+        _canUseRequestTransformFastPath = RequestTransforms.All(CanUseRequestTransformFastPath);
     }
 
     /// <summary>
@@ -68,6 +71,22 @@ internal sealed class StructuredTransformer : HttpTransformer
     /// </summary>
     internal ResponseTrailersTransform[] ResponseTrailerTransforms { get; }
 
+    private static bool CanUseRequestTransformFastPath(RequestTransform transform)
+    {
+        // Built-in transforms are inheritable, so exact type checks preserve derived ApplyAsync overrides.
+        var transformType = transform.GetType();
+        return transformType == typeof(RequestHeaderOriginalHostTransform)
+                || transformType == typeof(RequestHeaderXForwardedForTransform)
+                || transformType == typeof(RequestHeaderXForwardedHostTransform)
+                || transformType == typeof(RequestHeaderXForwardedProtoTransform)
+                || transformType == typeof(RequestHeaderXForwardedPrefixTransform)
+                || transformType == typeof(RequestHeaderForwardedTransform)
+                || transformType == typeof(RequestHeaderRemoveTransform)
+                || transformType == typeof(RequestHeaderValueTransform)
+                || transformType == typeof(RequestHeaderRouteValueTransform)
+                || transformType == typeof(RequestHeadersAllowedTransform);
+    }
+
 #pragma warning disable CS0672 // We're overriding the obsolete overloads to preserve backwards compatibility.
     public override ValueTask TransformRequestAsync(HttpContext httpContext, HttpRequestMessage proxyRequest, string destinationPrefix) =>
         TransformRequestAsync(httpContext, proxyRequest, destinationPrefix, CancellationToken.None);
@@ -95,6 +114,19 @@ internal sealed class StructuredTransformer : HttpTransformer
 
         if (RequestTransforms.Length == 0)
         {
+            return;
+        }
+
+        if (_canUseRequestTransformFastPath)
+        {
+            var headersCopied = ShouldCopyRequestHeaders.GetValueOrDefault(true);
+            foreach (var requestTransform in RequestTransforms)
+            {
+                requestTransform.ApplyFast(httpContext, proxyRequest, ref headersCopied);
+            }
+
+            proxyRequest.RequestUri ??= RequestUtilities.MakeDestinationAddress(
+                destinationPrefix, httpContext.Request.Path, httpContext.Request.QueryString);
             return;
         }
 

--- a/src/ReverseProxy/Transforms/RequestHeaderForwardedTransform.cs
+++ b/src/ReverseProxy/Transforms/RequestHeaderForwardedTransform.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Diagnostics;
 using System.Net;
+using System.Net.Http;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Primitives;
@@ -51,28 +52,35 @@ public class RequestHeaderForwardedTransform : RequestTransform
     public override ValueTask ApplyAsync(RequestTransformContext context)
     {
         ArgumentNullException.ThrowIfNull(context);
+        Apply(context.HttpContext, context.ProxyRequest, context.HeadersCopied);
+        return default;
+    }
 
-        var httpContext = context.HttpContext;
+    internal override void ApplyFast(HttpContext httpContext, HttpRequestMessage proxyRequest, ref bool headersCopied)
+    {
+        Apply(httpContext, proxyRequest, headersCopied);
+    }
 
+    private void Apply(HttpContext httpContext, HttpRequestMessage proxyRequest, bool headersCopied)
+    {
         switch (TransformAction)
         {
             case ForwardedTransformActions.Set:
-                RemoveHeader(context, ForwardedHeaderName);
-                AddHeader(context, ForwardedHeaderName, GetHeaderValue(httpContext));
+                RemoveHeader(proxyRequest, ForwardedHeaderName);
+                AddHeader(proxyRequest, ForwardedHeaderName, GetHeaderValue(httpContext));
                 break;
             case ForwardedTransformActions.Append:
-                var existingValues = TakeHeader(context, ForwardedHeaderName);
+                var existingValues = TakeHeader(httpContext, proxyRequest, headersCopied, ForwardedHeaderName);
                 var values = StringValues.Concat(existingValues, GetHeaderValue(httpContext));
-                AddHeader(context, ForwardedHeaderName, values);
+                AddHeader(proxyRequest, ForwardedHeaderName, values);
                 break;
             case ForwardedTransformActions.Remove:
-                RemoveHeader(context, ForwardedHeaderName);
+                RemoveHeader(proxyRequest, ForwardedHeaderName);
                 break;
             default:
                 throw new NotImplementedException(TransformAction.ToString());
         }
 
-        return default;
     }
 
     private string GetHeaderValue(HttpContext httpContext)

--- a/src/ReverseProxy/Transforms/RequestHeaderOriginalHostTransform.cs
+++ b/src/ReverseProxy/Transforms/RequestHeaderOriginalHostTransform.cs
@@ -2,7 +2,9 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
+using System.Net.Http;
 using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
 using Microsoft.Net.Http.Headers;
 using Yarp.ReverseProxy.Forwarder;
 using Yarp.ReverseProxy.Model;
@@ -32,17 +34,28 @@ public class RequestHeaderOriginalHostTransform : RequestTransform
 
     public override ValueTask ApplyAsync(RequestTransformContext context)
     {
-        var destinationConfigHost = context.HttpContext.Features.Get<IReverseProxyFeature>()?.ProxiedDestination?.Model.Config?.Host;
-        var originalHost = context.HttpContext.Request.Host.Value is { Length: > 0 } host ? host : null;
-        var existingHost = RequestUtilities.TryGetValues(context.ProxyRequest.Headers, HeaderNames.Host, out var currentHost) ? currentHost.ToString() : null;
+        Apply(context.HttpContext, context.ProxyRequest, context.HeadersCopied);
+        return default;
+    }
+
+    internal override void ApplyFast(HttpContext httpContext, HttpRequestMessage proxyRequest, ref bool headersCopied)
+    {
+        Apply(httpContext, proxyRequest, headersCopied);
+    }
+
+    private void Apply(HttpContext httpContext, HttpRequestMessage proxyRequest, bool headersCopied)
+    {
+        var destinationConfigHost = httpContext.Features.Get<IReverseProxyFeature>()?.ProxiedDestination?.Model.Config?.Host;
+        var originalHost = httpContext.Request.Host.Value is { Length: > 0 } host ? host : null;
+        var existingHost = RequestUtilities.TryGetValues(proxyRequest.Headers, HeaderNames.Host, out var currentHost) ? currentHost.ToString() : null;
 
         if (UseOriginalHost)
         {
-            if (!context.HeadersCopied && existingHost is null)
+            if (!headersCopied && existingHost is null)
             {
                 // Propagate the host if the transform pipeline didn't already override it.
                 // If there was no original host specified, allow the destination config host to flow through.
-                context.ProxyRequest.Headers.TryAddWithoutValidation(HeaderNames.Host, originalHost ?? destinationConfigHost);
+                proxyRequest.Headers.TryAddWithoutValidation(HeaderNames.Host, originalHost ?? destinationConfigHost);
             }
         }
         else if (existingHost is null || string.Equals(originalHost, existingHost, StringComparison.Ordinal))
@@ -50,9 +63,7 @@ public class RequestHeaderOriginalHostTransform : RequestTransform
             // Use the host from destination configuration (which may be null) if either:
             // * there is no host header set, or
             // * the original host header is being suppressed and has not been modified by the transform pipeline
-            context.ProxyRequest.Headers.Host = destinationConfigHost;
+            proxyRequest.Headers.Host = destinationConfigHost;
         }
-
-        return default;
     }
 }

--- a/src/ReverseProxy/Transforms/RequestHeaderRemoveTransform.cs
+++ b/src/ReverseProxy/Transforms/RequestHeaderRemoveTransform.cs
@@ -2,7 +2,9 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
+using System.Net.Http;
 using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
 
 namespace Yarp.ReverseProxy.Transforms;
 
@@ -27,9 +29,12 @@ public class RequestHeaderRemoveTransform : RequestTransform
     public override ValueTask ApplyAsync(RequestTransformContext context)
     {
         ArgumentNullException.ThrowIfNull(context);
-
-        RemoveHeader(context, HeaderName);
-
+        RemoveHeader(context.ProxyRequest, HeaderName);
         return default;
+    }
+
+    internal override void ApplyFast(HttpContext httpContext, HttpRequestMessage proxyRequest, ref bool headersCopied)
+    {
+        RemoveHeader(proxyRequest, HeaderName);
     }
 }

--- a/src/ReverseProxy/Transforms/RequestHeaderRouteValueTransform.cs
+++ b/src/ReverseProxy/Transforms/RequestHeaderRouteValueTransform.cs
@@ -2,6 +2,10 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Primitives;
 
 namespace Yarp.ReverseProxy.Transforms;
 
@@ -35,5 +39,24 @@ public class RequestHeaderRouteValueTransform : RequestHeaderTransform
 
         return value?.ToString();
     }
-}
 
+    internal override void ApplyFast(HttpContext httpContext, HttpRequestMessage proxyRequest, ref bool headersCopied)
+    {
+        if (!httpContext.Request.RouteValues.TryGetValue(RouteValueKey, out var routeValue)
+            || routeValue?.ToString() is not { } value)
+        {
+            return;
+        }
+
+        if (Append)
+        {
+            var existingValues = TakeHeader(httpContext, proxyRequest, headersCopied, HeaderName);
+            AddHeader(proxyRequest, HeaderName, StringValues.Concat(existingValues, value));
+        }
+        else
+        {
+            RemoveHeader(proxyRequest, HeaderName);
+            AddHeader(proxyRequest, HeaderName, value);
+        }
+    }
+}

--- a/src/ReverseProxy/Transforms/RequestHeaderValueTransform.cs
+++ b/src/ReverseProxy/Transforms/RequestHeaderValueTransform.cs
@@ -2,7 +2,10 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
+using System.Net.Http;
 using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Primitives;
 
 namespace Yarp.ReverseProxy.Transforms;
 
@@ -30,5 +33,19 @@ public class RequestHeaderValueTransform : RequestHeaderTransform
     protected override string GetValue(RequestTransformContext context)
     {
         return Value;
+    }
+
+    internal override void ApplyFast(HttpContext httpContext, HttpRequestMessage proxyRequest, ref bool headersCopied)
+    {
+        if (Append)
+        {
+            var existingValues = TakeHeader(httpContext, proxyRequest, headersCopied, HeaderName);
+            AddHeader(proxyRequest, HeaderName, StringValues.Concat(existingValues, Value));
+        }
+        else
+        {
+            RemoveHeader(proxyRequest, HeaderName);
+            AddHeader(proxyRequest, HeaderName, Value);
+        }
     }
 }

--- a/src/ReverseProxy/Transforms/RequestHeaderXForwardedForTransform.cs
+++ b/src/ReverseProxy/Transforms/RequestHeaderXForwardedForTransform.cs
@@ -3,7 +3,9 @@
 
 using System;
 using System.Diagnostics;
+using System.Net.Http;
 using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Primitives;
 
 namespace Yarp.ReverseProxy.Transforms;
@@ -38,9 +40,19 @@ public class RequestHeaderXForwardedForTransform : RequestTransform
     public override ValueTask ApplyAsync(RequestTransformContext context)
     {
         ArgumentNullException.ThrowIfNull(context);
+        Apply(context.HttpContext, context.ProxyRequest, context.HeadersCopied);
+        return default;
+    }
 
+    internal override void ApplyFast(HttpContext httpContext, HttpRequestMessage proxyRequest, ref bool headersCopied)
+    {
+        Apply(httpContext, proxyRequest, headersCopied);
+    }
+
+    private void Apply(HttpContext httpContext, HttpRequestMessage proxyRequest, bool headersCopied)
+    {
         string? remoteIp = null;
-        var remoteIpAddress = context.HttpContext.Connection.RemoteIpAddress;
+        var remoteIpAddress = httpContext.Connection.RemoteIpAddress;
         if (remoteIpAddress is not null)
         {
             remoteIp = remoteIpAddress.IsIPv4MappedToIPv6 ?
@@ -51,39 +63,38 @@ public class RequestHeaderXForwardedForTransform : RequestTransform
         switch (TransformAction)
         {
             case ForwardedTransformActions.Set:
-                RemoveHeader(context, HeaderName);
+                RemoveHeader(proxyRequest, HeaderName);
                 if (remoteIp is not null)
                 {
-                    AddHeader(context, HeaderName, remoteIp);
+                    AddHeader(proxyRequest, HeaderName, remoteIp);
                 }
                 break;
             case ForwardedTransformActions.Append:
-                Append(context, remoteIp);
+                Append(httpContext, proxyRequest, headersCopied, remoteIp);
                 break;
             case ForwardedTransformActions.Remove:
-                RemoveHeader(context, HeaderName);
+                RemoveHeader(proxyRequest, HeaderName);
                 break;
             default:
                 throw new NotImplementedException(TransformAction.ToString());
         }
 
-        return default;
     }
 
-    private void Append(RequestTransformContext context, string? remoteIp)
+    private void Append(HttpContext httpContext, HttpRequestMessage proxyRequest, bool headersCopied, string? remoteIp)
     {
-        var existingValues = TakeHeader(context, HeaderName);
+        var existingValues = TakeHeader(httpContext, proxyRequest, headersCopied, HeaderName);
         if (remoteIp is null)
         {
             if (!string.IsNullOrEmpty(existingValues))
             {
-                AddHeader(context, HeaderName, existingValues);
+                AddHeader(proxyRequest, HeaderName, existingValues);
             }
         }
         else
         {
             var values = StringValues.Concat(existingValues, remoteIp);
-            AddHeader(context, HeaderName, values);
+            AddHeader(proxyRequest, HeaderName, values);
         }
     }
 }

--- a/src/ReverseProxy/Transforms/RequestHeaderXForwardedHostTransform.cs
+++ b/src/ReverseProxy/Transforms/RequestHeaderXForwardedHostTransform.cs
@@ -3,7 +3,9 @@
 
 using System;
 using System.Diagnostics;
+using System.Net.Http;
 using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Primitives;
 
 namespace Yarp.ReverseProxy.Transforms;
@@ -34,45 +36,54 @@ public class RequestHeaderXForwardedHostTransform : RequestTransform
     public override ValueTask ApplyAsync(RequestTransformContext context)
     {
         ArgumentNullException.ThrowIfNull(context);
+        Apply(context.HttpContext, context.ProxyRequest, context.HeadersCopied);
+        return default;
+    }
 
-        var host = context.HttpContext.Request.Host;
+    internal override void ApplyFast(HttpContext httpContext, HttpRequestMessage proxyRequest, ref bool headersCopied)
+    {
+        Apply(httpContext, proxyRequest, headersCopied);
+    }
+
+    private void Apply(HttpContext httpContext, HttpRequestMessage proxyRequest, bool headersCopied)
+    {
+        var host = httpContext.Request.Host;
 
         switch (TransformAction)
         {
             case ForwardedTransformActions.Set:
-                RemoveHeader(context, HeaderName);
+                RemoveHeader(proxyRequest, HeaderName);
                 if (host.HasValue)
                 {
-                    AddHeader(context, HeaderName, host.ToUriComponent());
+                    AddHeader(proxyRequest, HeaderName, host.ToUriComponent());
                 }
                 break;
             case ForwardedTransformActions.Append:
-                Append(context, host);
+                Append(httpContext, proxyRequest, headersCopied, host);
                 break;
             case ForwardedTransformActions.Remove:
-                RemoveHeader(context, HeaderName);
+                RemoveHeader(proxyRequest, HeaderName);
                 break;
             default:
                 throw new NotImplementedException(TransformAction.ToString());
         }
 
-        return default;
     }
 
-    private void Append(RequestTransformContext context, Microsoft.AspNetCore.Http.HostString host)
+    private void Append(HttpContext httpContext, HttpRequestMessage proxyRequest, bool headersCopied, HostString host)
     {
-        var existingValues = TakeHeader(context, HeaderName);
+        var existingValues = TakeHeader(httpContext, proxyRequest, headersCopied, HeaderName);
         if (!host.HasValue)
         {
             if (!string.IsNullOrEmpty(existingValues))
             {
-                AddHeader(context, HeaderName, existingValues);
+                AddHeader(proxyRequest, HeaderName, existingValues);
             }
         }
         else
         {
             var values = StringValues.Concat(existingValues, host.ToUriComponent());
-            AddHeader(context, HeaderName, values);
+            AddHeader(proxyRequest, HeaderName, values);
         }
     }
 }

--- a/src/ReverseProxy/Transforms/RequestHeaderXForwardedPrefixTransform.cs
+++ b/src/ReverseProxy/Transforms/RequestHeaderXForwardedPrefixTransform.cs
@@ -3,7 +3,9 @@
 
 using System;
 using System.Diagnostics;
+using System.Net.Http;
 using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Primitives;
 
 namespace Yarp.ReverseProxy.Transforms;
@@ -32,45 +34,54 @@ public class RequestHeaderXForwardedPrefixTransform : RequestTransform
     public override ValueTask ApplyAsync(RequestTransformContext context)
     {
         ArgumentNullException.ThrowIfNull(context);
+        Apply(context.HttpContext, context.ProxyRequest, context.HeadersCopied);
+        return default;
+    }
 
-        var pathBase = context.HttpContext.Request.PathBase;
+    internal override void ApplyFast(HttpContext httpContext, HttpRequestMessage proxyRequest, ref bool headersCopied)
+    {
+        Apply(httpContext, proxyRequest, headersCopied);
+    }
+
+    private void Apply(HttpContext httpContext, HttpRequestMessage proxyRequest, bool headersCopied)
+    {
+        var pathBase = httpContext.Request.PathBase;
 
         switch (TransformAction)
         {
             case ForwardedTransformActions.Set:
-                RemoveHeader(context, HeaderName);
+                RemoveHeader(proxyRequest, HeaderName);
                 if (pathBase.HasValue)
                 {
-                    AddHeader(context, HeaderName, pathBase.ToUriComponent());
+                    AddHeader(proxyRequest, HeaderName, pathBase.ToUriComponent());
                 }
                 break;
             case ForwardedTransformActions.Append:
-                Append(context, pathBase);
+                Append(httpContext, proxyRequest, headersCopied, pathBase);
                 break;
             case ForwardedTransformActions.Remove:
-                RemoveHeader(context, HeaderName);
+                RemoveHeader(proxyRequest, HeaderName);
                 break;
             default:
                 throw new NotImplementedException(TransformAction.ToString());
         }
 
-        return default;
     }
 
-    private void Append(RequestTransformContext context, Microsoft.AspNetCore.Http.PathString pathBase)
+    private void Append(HttpContext httpContext, HttpRequestMessage proxyRequest, bool headersCopied, PathString pathBase)
     {
-        var existingValues = TakeHeader(context, HeaderName);
+        var existingValues = TakeHeader(httpContext, proxyRequest, headersCopied, HeaderName);
         if (!pathBase.HasValue)
         {
             if (!string.IsNullOrEmpty(existingValues))
             {
-                AddHeader(context, HeaderName, existingValues);
+                AddHeader(proxyRequest, HeaderName, existingValues);
             }
         }
         else
         {
             var values = StringValues.Concat(existingValues, pathBase.ToUriComponent());
-            AddHeader(context, HeaderName, values);
+            AddHeader(proxyRequest, HeaderName, values);
         }
     }
 }

--- a/src/ReverseProxy/Transforms/RequestHeaderXForwardedProtoTransform.cs
+++ b/src/ReverseProxy/Transforms/RequestHeaderXForwardedProtoTransform.cs
@@ -3,7 +3,9 @@
 
 using System;
 using System.Diagnostics;
+using System.Net.Http;
 using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Primitives;
 
 namespace Yarp.ReverseProxy.Transforms;
@@ -37,27 +39,36 @@ public class RequestHeaderXForwardedProtoTransform : RequestTransform
     public override ValueTask ApplyAsync(RequestTransformContext context)
     {
         ArgumentNullException.ThrowIfNull(context);
+        Apply(context.HttpContext, context.ProxyRequest, context.HeadersCopied);
+        return default;
+    }
 
-        var scheme = context.HttpContext.Request.Scheme;
+    internal override void ApplyFast(HttpContext httpContext, HttpRequestMessage proxyRequest, ref bool headersCopied)
+    {
+        Apply(httpContext, proxyRequest, headersCopied);
+    }
+
+    private void Apply(HttpContext httpContext, HttpRequestMessage proxyRequest, bool headersCopied)
+    {
+        var scheme = httpContext.Request.Scheme;
 
         switch (TransformAction)
         {
             case ForwardedTransformActions.Set:
-                RemoveHeader(context, HeaderName);
-                AddHeader(context, HeaderName, scheme);
+                RemoveHeader(proxyRequest, HeaderName);
+                AddHeader(proxyRequest, HeaderName, scheme);
                 break;
             case ForwardedTransformActions.Append:
-                var existingValues = TakeHeader(context, HeaderName);
+                var existingValues = TakeHeader(httpContext, proxyRequest, headersCopied, HeaderName);
                 var values = StringValues.Concat(existingValues, scheme);
-                AddHeader(context, HeaderName, values);
+                AddHeader(proxyRequest, HeaderName, values);
                 break;
             case ForwardedTransformActions.Remove:
-                RemoveHeader(context, HeaderName);
+                RemoveHeader(proxyRequest, HeaderName);
                 break;
             default:
                 throw new NotImplementedException(TransformAction.ToString());
         }
 
-        return default;
     }
 }

--- a/src/ReverseProxy/Transforms/RequestHeadersAllowedTransform.cs
+++ b/src/ReverseProxy/Transforms/RequestHeadersAllowedTransform.cs
@@ -5,7 +5,9 @@ using System;
 using System.Collections.Frozen;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Net.Http;
 using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Primitives;
 
 namespace Yarp.ReverseProxy.Transforms;
@@ -33,20 +35,29 @@ public class RequestHeadersAllowedTransform : RequestTransform
         ArgumentNullException.ThrowIfNull(context);
 
         Debug.Assert(!context.HeadersCopied);
+        Apply(context.HttpContext, context.ProxyRequest);
+        context.HeadersCopied = true;
+        return default;
+    }
 
-        foreach (var header in context.HttpContext.Request.Headers)
+    internal override void ApplyFast(HttpContext httpContext, HttpRequestMessage proxyRequest, ref bool headersCopied)
+    {
+        Debug.Assert(!headersCopied);
+        Apply(httpContext, proxyRequest);
+        headersCopied = true;
+    }
+
+    private void Apply(HttpContext httpContext, HttpRequestMessage proxyRequest)
+    {
+        foreach (var header in httpContext.Request.Headers)
         {
             var headerName = header.Key;
             var headerValue = header.Value;
             if (!StringValues.IsNullOrEmpty(headerValue)
                 && AllowedHeadersSet.Contains(headerName))
             {
-                AddHeader(context, headerName, headerValue);
+                AddHeader(proxyRequest, headerName, headerValue);
             }
         }
-
-        context.HeadersCopied = true;
-
-        return default;
     }
 }

--- a/src/ReverseProxy/Transforms/RequestTransform.cs
+++ b/src/ReverseProxy/Transforms/RequestTransform.cs
@@ -2,7 +2,9 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
+using System.Net.Http;
 using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Primitives;
 using Yarp.ReverseProxy.Forwarder;
 
@@ -17,6 +19,11 @@ public abstract class RequestTransform
     /// Transforms any of the available fields before building the outgoing request.
     /// </summary>
     public abstract ValueTask ApplyAsync(RequestTransformContext context);
+
+    internal virtual void ApplyFast(HttpContext httpContext, HttpRequestMessage proxyRequest, ref bool headersCopied)
+    {
+        throw new NotSupportedException();
+    }
 
     /// <summary>
     /// Removes and returns the current header value by first checking the HttpRequestMessage,
@@ -34,8 +41,11 @@ public abstract class RequestTransform
             throw new ArgumentException($"'{nameof(headerName)}' cannot be null or empty.", nameof(headerName));
         }
 
-        var proxyRequest = context.ProxyRequest;
+        return TakeHeader(context.HttpContext, context.ProxyRequest, context.HeadersCopied, headerName);
+    }
 
+    internal static StringValues TakeHeader(HttpContext httpContext, HttpRequestMessage proxyRequest, bool headersCopied, string headerName)
+    {
         if (RequestUtilities.TryGetValues(proxyRequest.Headers, headerName, out var existingValues))
         {
             proxyRequest.Headers.Remove(headerName);
@@ -44,9 +54,9 @@ public abstract class RequestTransform
         {
             content.Headers.Remove(headerName);
         }
-        else if (!context.HeadersCopied)
+        else if (!headersCopied)
         {
-            existingValues = context.HttpContext.Request.Headers[headerName];
+            existingValues = httpContext.Request.Headers[headerName];
         }
 
         return existingValues;
@@ -60,7 +70,12 @@ public abstract class RequestTransform
         ArgumentNullException.ThrowIfNull(context);
         ArgumentException.ThrowIfNullOrEmpty(headerName);
 
-        RequestUtilities.AddHeader(context.ProxyRequest, headerName, values);
+        AddHeader(context.ProxyRequest, headerName, values);
+    }
+
+    internal static void AddHeader(HttpRequestMessage proxyRequest, string headerName, StringValues values)
+    {
+        RequestUtilities.AddHeader(proxyRequest, headerName, values);
     }
 
     /// <summary>
@@ -71,6 +86,11 @@ public abstract class RequestTransform
         ArgumentNullException.ThrowIfNull(context);
         ArgumentException.ThrowIfNullOrEmpty(headerName);
 
-        RequestUtilities.RemoveHeader(context.ProxyRequest, headerName);
+        RemoveHeader(context.ProxyRequest, headerName);
+    }
+
+    internal static void RemoveHeader(HttpRequestMessage proxyRequest, string headerName)
+    {
+        RequestUtilities.RemoveHeader(proxyRequest, headerName);
     }
 }

--- a/test/ReverseProxy.Tests/Transforms/Builder/StructuredTransformerFastPathTests.cs
+++ b/test/ReverseProxy.Tests/Transforms/Builder/StructuredTransformerFastPathTests.cs
@@ -8,6 +8,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Net;
 using System.Net.Http;
+using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
@@ -42,6 +43,8 @@ public class StructuredTransformerFastPathTests
 
         var optimized = CreateTransformer(Configure);
         var fallback = CreateTransformerWithFallback(Configure);
+        Assert.True(UsesFastPath(optimized));
+        Assert.False(UsesFastPath(fallback));
 
         var optimizedResult = await TransformRequestAsync(optimized, protocol, IPAddress.Parse(remoteIp), cancellation.Token);
         var fallbackResult = await TransformRequestAsync(fallback, protocol, IPAddress.Parse(remoteIp), cancellation.Token);
@@ -72,6 +75,8 @@ public class StructuredTransformerFastPathTests
 
         var optimized = CreateTransformer(Configure);
         var fallback = CreateTransformerWithFallback(Configure);
+        Assert.True(UsesFastPath(optimized));
+        Assert.False(UsesFastPath(fallback));
 
         var optimizedResult = await TransformRequestAsync(optimized, protocol, IPAddress.Parse(remoteIp), default, remotePort);
         var fallbackResult = await TransformRequestAsync(fallback, protocol, IPAddress.Parse(remoteIp), default, remotePort);
@@ -96,6 +101,7 @@ public class StructuredTransformerFastPathTests
         }
 
         var transformer = CreateTransformer(Configure);
+        Assert.False(UsesFastPath(transformer));
         var result = await TransformRequestAsync(transformer, protocol, IPAddress.IPv6Loopback, default);
 
         Assert.Equal("http://destination/base/v2/%252F/items/%252Fvalue?key=replacement&escaped=a%2Fb&added=a%2Fb", result.Uri);
@@ -125,6 +131,7 @@ public class StructuredTransformerFastPathTests
                 transformContext.ProxyRequest.Headers.TryAddWithoutValidation("X-Async", "set");
             });
         });
+        Assert.False(UsesFastPath(transformer));
 
         var result = await TransformRequestAsync(transformer, "HTTP/2", IPAddress.Loopback, cancellation.Token);
 
@@ -141,10 +148,92 @@ public class StructuredTransformerFastPathTests
             context.UseDefaultForwarders = false;
             context.RequestTransforms.Add(new DerivedRequestHeaderValueTransform());
         });
+        Assert.False(UsesFastPath(transformer));
 
         var result = await TransformRequestAsync(transformer, "HTTP/2", IPAddress.Loopback, default);
 
         Assert.Contains("X-Derived:derived", result.Headers);
+    }
+
+    [Fact]
+    public async Task HeadersAllowed_OrderingAndHeadersCopied_MatchContextFallback()
+    {
+        static void Configure(TransformBuilderContext context)
+        {
+            context.UseDefaultForwarders = false;
+            context.AddRequestHeader("X-Before", "before", append: true);
+            context.AddRequestHeadersAllowed("X-Before", "X-After");
+            context.AddRequestHeader("X-After", "after", append: true);
+        }
+
+        var optimized = CreateTransformer(Configure);
+        var fallback = CreateTransformerWithFallback(Configure);
+        Assert.True(UsesFastPath(optimized));
+        Assert.False(UsesFastPath(fallback));
+
+        var optimizedResult = await TransformRequestAsync(optimized, "HTTP/2", IPAddress.Loopback, default);
+        var fallbackResult = await TransformRequestAsync(fallback, "HTTP/2", IPAddress.Loopback, default);
+
+        Assert.Equal(fallbackResult, optimizedResult);
+        Assert.Contains("X-Before:original-before\u001fbefore\u001foriginal-before", optimizedResult.Headers);
+        Assert.Contains("X-After:original-after\u001fafter", optimizedResult.Headers);
+    }
+
+    [Fact]
+    public async Task OriginalHostAndRouteValue_MatchContextFallback()
+    {
+        static void Configure(TransformBuilderContext context)
+        {
+            context.UseDefaultForwarders = false;
+            context.AddOriginalHost(useOriginal: true);
+            context.AddRequestHeaderRouteValue("X-Route", "id", append: false);
+        }
+
+        var optimized = CreateTransformer(Configure);
+        var fallback = CreateTransformerWithFallback(Configure);
+        Assert.True(UsesFastPath(optimized));
+        Assert.False(UsesFastPath(fallback));
+
+        var optimizedResult = await TransformRequestAsync(optimized, "HTTP/2", IPAddress.Loopback, default);
+        var fallbackResult = await TransformRequestAsync(fallback, "HTTP/2", IPAddress.Loopback, default);
+
+        Assert.Equal(fallbackResult, optimizedResult);
+        Assert.Contains("Host:xn--host-6j1i.example:8443", optimizedResult.Headers);
+        Assert.Contains("X-Route:route-value", optimizedResult.Headers);
+    }
+
+    [Fact]
+    public void EligibleBuiltIns_OverrideFastPath()
+    {
+        RequestTransform[] transforms =
+        [
+            RequestHeaderOriginalHostTransform.OriginalHost,
+            new RequestHeaderXForwardedForTransform("X-Forwarded-For", ForwardedTransformActions.Set),
+            new RequestHeaderXForwardedHostTransform("X-Forwarded-Host", ForwardedTransformActions.Set),
+            new RequestHeaderXForwardedProtoTransform("X-Forwarded-Proto", ForwardedTransformActions.Set),
+            new RequestHeaderXForwardedPrefixTransform("X-Forwarded-Prefix", ForwardedTransformActions.Set),
+            new RequestHeaderForwardedTransform(
+                new TestRandomFactory(),
+                NodeFormat.Ip,
+                NodeFormat.None,
+                host: true,
+                proto: true,
+                ForwardedTransformActions.Set),
+            new RequestHeaderRemoveTransform("X-Remove"),
+            new RequestHeaderValueTransform("X-Value", "value", append: false),
+            new RequestHeaderRouteValueTransform("X-Route", "id", append: false),
+            new RequestHeadersAllowedTransform(["X-Allowed"]),
+        ];
+
+        foreach (var transform in transforms)
+        {
+            var method = transform.GetType().GetMethod(
+                "ApplyFast",
+                BindingFlags.Instance | BindingFlags.NonPublic);
+
+            Assert.NotNull(method);
+            Assert.Equal(transform.GetType(), method.DeclaringType);
+        }
     }
 
     [Theory]
@@ -162,6 +251,8 @@ public class StructuredTransformerFastPathTests
 
         var optimized = CreateTransformer(Configure);
         var fallback = CreateTransformerWithFallback(Configure);
+        Assert.True(UsesFastPath(optimized));
+        Assert.False(UsesFastPath(fallback));
 
         var optimizedResult = await TransformResponseAsync(optimized, protocol);
         var fallbackResult = await TransformResponseAsync(fallback, protocol);
@@ -182,6 +273,8 @@ public class StructuredTransformerFastPathTests
 
         var optimized = CreateTransformer(Configure);
         var fallback = CreateTransformerWithFallback(Configure);
+        Assert.True(UsesFastPath(optimized));
+        Assert.False(UsesFastPath(fallback));
 
         await Parallel.ForEachAsync(Enumerable.Range(0, 200), async (index, _) =>
         {
@@ -266,8 +359,20 @@ public class StructuredTransformerFastPathTests
         context.Request.Headers["X-Duplicate"] = new StringValues(new[] { "one", "two" });
         context.Request.Headers["X-Remove"] = "remove";
         context.Request.Headers["X-Mixed-Set"] = "old";
+        context.Request.Headers["X-Before"] = "original-before";
+        context.Request.Headers["X-After"] = "original-after";
         context.Request.Headers[HeaderNames.TE] = "gzip, traiLers";
+        context.Request.RouteValues["id"] = "route-value";
         return context;
+    }
+
+    private static bool UsesFastPath(StructuredTransformer transformer)
+    {
+        var field = typeof(StructuredTransformer).GetField(
+            "_canUseRequestTransformFastPath",
+            BindingFlags.Instance | BindingFlags.NonPublic);
+        Assert.NotNull(field);
+        return Assert.IsType<bool>(field.GetValue(transformer));
     }
 
     private static string[] GetHeaders(HttpRequestMessage request)

--- a/test/ReverseProxy.Tests/Transforms/Builder/StructuredTransformerFastPathTests.cs
+++ b/test/ReverseProxy.Tests/Transforms/Builder/StructuredTransformerFastPathTests.cs
@@ -1,0 +1,332 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#nullable enable
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.Features;
+using Microsoft.Extensions.Primitives;
+using Microsoft.Net.Http.Headers;
+using Xunit;
+using Yarp.ReverseProxy.Forwarder;
+using Yarp.ReverseProxy.Utilities;
+using Yarp.Tests.Common;
+
+namespace Yarp.ReverseProxy.Transforms.Builder.Tests;
+
+public class StructuredTransformerFastPathTests
+{
+    [Theory]
+    [InlineData("HTTP/1.1", "127.0.0.1")]
+    [InlineData("HTTP/2", "::ffff:127.0.0.1")]
+    [InlineData("HTTP/2", "2001:db8::1")]
+    public async Task BuiltInXForwardedAndHeaderTransforms_MatchContextFallback(string protocol, string remoteIp)
+    {
+        static void Configure(TransformBuilderContext context)
+        {
+            context.AddXForwarded(ForwardedTransformActions.Append);
+            context.AddRequestHeader("x-MiXeD-Set", "set", append: false);
+            context.AddRequestHeader("X-Duplicate", "tail", append: true);
+            context.AddRequestHeaderRemove("x-REMOVE");
+        }
+
+        using var cancellation = new CancellationTokenSource();
+        cancellation.Cancel();
+
+        var optimized = CreateTransformer(Configure);
+        var fallback = CreateTransformerWithFallback(Configure);
+
+        var optimizedResult = await TransformRequestAsync(optimized, protocol, IPAddress.Parse(remoteIp), cancellation.Token);
+        var fallbackResult = await TransformRequestAsync(fallback, protocol, IPAddress.Parse(remoteIp), cancellation.Token);
+
+        Assert.Equal(fallbackResult, optimizedResult);
+        Assert.Contains("X-Duplicate:one\u001ftwo\u001ftail", optimizedResult.Headers);
+        Assert.Contains("x-MiXeD-Set:set", optimizedResult.Headers);
+        Assert.DoesNotContain(optimizedResult.Headers, header => header.StartsWith("x-REMOVE:", StringComparison.OrdinalIgnoreCase));
+    }
+
+    [Theory]
+    [InlineData("HTTP/1.1", "127.0.0.1", 1234)]
+    [InlineData("HTTP/2", "2001:db8::1", 4321)]
+    public async Task ForwardedTransform_MatchesContextFallback(string protocol, string remoteIp, int remotePort)
+    {
+        static void Configure(TransformBuilderContext context)
+        {
+            context.UseDefaultForwarders = false;
+            context.RequestTransforms.Add(new RequestHeaderForwardedTransform(
+                new TestRandomFactory(),
+                forFormat: NodeFormat.IpAndPort,
+                byFormat: NodeFormat.None,
+                host: true,
+                proto: true,
+                action: ForwardedTransformActions.Append));
+            context.AddRequestHeader("X-Set", "replacement", append: false);
+        }
+
+        var optimized = CreateTransformer(Configure);
+        var fallback = CreateTransformerWithFallback(Configure);
+
+        var optimizedResult = await TransformRequestAsync(optimized, protocol, IPAddress.Parse(remoteIp), default, remotePort);
+        var fallbackResult = await TransformRequestAsync(fallback, protocol, IPAddress.Parse(remoteIp), default, remotePort);
+
+        Assert.Equal(fallbackResult, optimizedResult);
+        Assert.Contains(optimizedResult.Headers, header =>
+            header.StartsWith("Forwarded:for=\"unterminated\u001ffor=", StringComparison.Ordinal));
+    }
+
+    [Theory]
+    [InlineData("HTTP/1.1")]
+    [InlineData("HTTP/2")]
+    public async Task PathQueryEncodingAndOrdering_ArePreserved(string protocol)
+    {
+        static void Configure(TransformBuilderContext context)
+        {
+            context.AddPathRemovePrefix("/api");
+            context.AddPathPrefix("/v2/%2F");
+            context.AddQueryValue("key", "replacement", append: false);
+            context.AddQueryValue("added", "a/b", append: true);
+            context.AddQueryRemoveKey("remove");
+        }
+
+        var transformer = CreateTransformer(Configure);
+        var result = await TransformRequestAsync(transformer, protocol, IPAddress.IPv6Loopback, default);
+
+        Assert.Equal("http://destination/base/v2/%252F/items/%252Fvalue?key=replacement&escaped=a%2Fb&added=a%2Fb", result.Uri);
+        Assert.Equal(protocol == "HTTP/2", result.Headers.Contains("TE:traiLers"));
+    }
+
+    [Fact]
+    public async Task CustomSyncAndAsyncTransforms_PreserveReassignmentAndCancellation()
+    {
+        using var cancellation = new CancellationTokenSource();
+        cancellation.Cancel();
+        var observedToken = default(CancellationToken);
+        var transformer = CreateTransformer(context =>
+        {
+            context.AddRequestTransform(transformContext =>
+            {
+                observedToken = transformContext.CancellationToken;
+                transformContext.DestinationPrefix = "https://other.example/base";
+                transformContext.Path = "/reassigned/%2F";
+                transformContext.Query = new QueryTransformContext(transformContext.HttpContext.Request);
+                transformContext.Query.Collection["custom"] = "one/two";
+                return default;
+            });
+            context.AddRequestTransform(async transformContext =>
+            {
+                await Task.Yield();
+                transformContext.ProxyRequest.Headers.TryAddWithoutValidation("X-Async", "set");
+            });
+        });
+
+        var result = await TransformRequestAsync(transformer, "HTTP/2", IPAddress.Loopback, cancellation.Token);
+
+        Assert.Equal(cancellation.Token, observedToken);
+        Assert.Equal("https://other.example/base/reassigned/%252F?key=one&key=two&remove=yes&escaped=a%2Fb&custom=one%2Ftwo", result.Uri);
+        Assert.Contains("X-Async:set", result.Headers);
+    }
+
+    [Fact]
+    public async Task DerivedBuiltInTransform_UsesOverriddenApplyAsync()
+    {
+        var transformer = CreateTransformer(context =>
+        {
+            context.UseDefaultForwarders = false;
+            context.RequestTransforms.Add(new DerivedRequestHeaderValueTransform());
+        });
+
+        var result = await TransformRequestAsync(transformer, "HTTP/2", IPAddress.Loopback, default);
+
+        Assert.Contains("X-Derived:derived", result.Headers);
+    }
+
+    [Theory]
+    [InlineData("HTTP/1.1")]
+    [InlineData("HTTP/2")]
+    public async Task ResponseHeadersAndTrailers_MatchContextFallback(string protocol)
+    {
+        static void Configure(TransformBuilderContext context)
+        {
+            context.AddXForwarded();
+            context.AddResponseHeader("X-Append", "tail", append: true, ResponseCondition.Always);
+            context.AddResponseHeaderRemove("X-Remove", ResponseCondition.Always);
+            context.AddResponseTrailer("X-Trailer", "tail", append: true, ResponseCondition.Always);
+        }
+
+        var optimized = CreateTransformer(Configure);
+        var fallback = CreateTransformerWithFallback(Configure);
+
+        var optimizedResult = await TransformResponseAsync(optimized, protocol);
+        var fallbackResult = await TransformResponseAsync(fallback, protocol);
+
+        Assert.Equal(fallbackResult, optimizedResult);
+        Assert.Contains("X-Append:one\u001ftwo\u001ftail", optimizedResult.Headers);
+        Assert.Contains("X-Trailer:one\u001ftwo\u001ftail", optimizedResult.Trailers);
+    }
+
+    [Fact]
+    public async Task BuiltInTransforms_AreConcurrencySafe()
+    {
+        static void Configure(TransformBuilderContext context)
+        {
+            context.AddXForwarded(ForwardedTransformActions.Append);
+            context.AddRequestHeader("X-Duplicate", "tail", append: true);
+        }
+
+        var optimized = CreateTransformer(Configure);
+        var fallback = CreateTransformerWithFallback(Configure);
+
+        await Parallel.ForEachAsync(Enumerable.Range(0, 200), async (index, _) =>
+        {
+            var protocol = index % 2 == 0 ? "HTTP/1.1" : "HTTP/2";
+            var ipAddress = index % 3 == 0 ? IPAddress.Loopback : IPAddress.IPv6Loopback;
+            var optimizedResult = await TransformRequestAsync(optimized, protocol, ipAddress, default, index);
+            var fallbackResult = await TransformRequestAsync(fallback, protocol, ipAddress, default, index);
+            Assert.Equal(fallbackResult, optimizedResult);
+        });
+    }
+
+    private static StructuredTransformer CreateTransformer(Action<TransformBuilderContext> configure)
+    {
+        return TransformBuilderTests.CreateTransformBuilder().CreateInternal(configure);
+    }
+
+    private static StructuredTransformer CreateTransformerWithFallback(Action<TransformBuilderContext> configure)
+    {
+        return TransformBuilderTests.CreateTransformBuilder().CreateInternal(context =>
+        {
+            configure(context);
+            context.AddRequestTransform(static _ => default);
+        });
+    }
+
+    private static async Task<RequestSnapshot> TransformRequestAsync(
+        StructuredTransformer transformer,
+        string protocol,
+        IPAddress remoteIp,
+        CancellationToken cancellationToken,
+        int remotePort = 4321)
+    {
+        var context = CreateHttpContext(protocol, remoteIp, remotePort);
+        using var request = new HttpRequestMessage
+        {
+            Content = new ByteArrayContent(Array.Empty<byte>()),
+        };
+
+        await transformer.TransformRequestAsync(context, request, "http://destination/base", cancellationToken);
+
+        return new RequestSnapshot(request.RequestUri!.AbsoluteUri, GetHeaders(request));
+    }
+
+    private static async Task<ResponseSnapshot> TransformResponseAsync(StructuredTransformer transformer, string protocol)
+    {
+        var context = CreateHttpContext(protocol, IPAddress.IPv6Loopback, 4321);
+        var trailersFeature = new TestTrailersFeature();
+        context.Features.Set<IHttpResponseTrailersFeature>(trailersFeature);
+        using var response = new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new ByteArrayContent(Array.Empty<byte>()),
+        };
+        response.Headers.TryAddWithoutValidation("X-Append", new[] { "one", "two" });
+        response.Headers.TryAddWithoutValidation("X-Remove", "remove");
+        response.TrailingHeaders.TryAddWithoutValidation("X-Trailer", new[] { "one", "two" });
+
+        await transformer.TransformResponseAsync(context, response, default);
+        await transformer.TransformResponseTrailersAsync(context, response, default);
+
+        return new ResponseSnapshot(GetHeaders(context.Response.Headers), GetHeaders(trailersFeature.Trailers));
+    }
+
+    private static DefaultHttpContext CreateHttpContext(string protocol, IPAddress remoteIp, int remotePort)
+    {
+        var context = new DefaultHttpContext();
+        context.Request.Protocol = protocol;
+        context.Request.Scheme = "https";
+        context.Request.Host = new HostString("ho本st.example", 8443);
+        context.Request.PathBase = "/base";
+        context.Request.Path = "/api/items/%2Fvalue";
+        context.Request.QueryString = new QueryString("?key=one&key=two&remove=yes&escaped=a%2Fb");
+        context.Connection.RemoteIpAddress = remoteIp;
+        context.Connection.RemotePort = remotePort;
+        context.Connection.LocalIpAddress = IPAddress.Loopback;
+        context.Connection.LocalPort = 443;
+
+        context.Request.Headers["x-forwarded-for"] = new StringValues(new[] { "192.0.2.1", "2001:db8::2" });
+        context.Request.Headers["X-FORWARDED-HOST"] = new StringValues(new[] { "prior.example", "older.example" });
+        context.Request.Headers["x-forwarded-proto"] = new StringValues(new[] { "http", "https" });
+        context.Request.Headers["X-Forwarded-Prefix"] = new StringValues(new[] { "/prior", "/older" });
+        context.Request.Headers["Forwarded"] = new StringValues(new[] { "for=\"unterminated", "for=192.0.2.1;proto=http" });
+        context.Request.Headers["X-Duplicate"] = new StringValues(new[] { "one", "two" });
+        context.Request.Headers["X-Remove"] = "remove";
+        context.Request.Headers["X-Mixed-Set"] = "old";
+        context.Request.Headers[HeaderNames.TE] = "gzip, traiLers";
+        return context;
+    }
+
+    private static string[] GetHeaders(HttpRequestMessage request)
+    {
+        return request.Headers.NonValidated
+            .Concat(request.Content!.Headers.NonValidated)
+            .Select(header => $"{header.Key}:{string.Join('\u001f', header.Value)}")
+            .OrderBy(header => header, StringComparer.Ordinal)
+            .ToArray();
+    }
+
+    private static string[] GetHeaders(IHeaderDictionary headers)
+    {
+        return headers
+            .Select(header => $"{header.Key}:{string.Join('\u001f', header.Value.ToArray())}")
+            .OrderBy(header => header, StringComparer.Ordinal)
+            .ToArray();
+    }
+
+    private sealed record RequestSnapshot(string Uri, string[] Headers)
+    {
+        public bool Equals(RequestSnapshot? other)
+        {
+            return other is not null
+                && string.Equals(Uri, other.Uri, StringComparison.Ordinal)
+                && Headers.SequenceEqual(other.Headers, StringComparer.Ordinal);
+        }
+
+        public override int GetHashCode() => HashCode.Combine(Uri, Headers.Length);
+    }
+
+    private sealed record ResponseSnapshot(string[] Headers, string[] Trailers)
+    {
+        public bool Equals(ResponseSnapshot? other)
+        {
+            return other is not null
+                && Headers.SequenceEqual(other.Headers, StringComparer.Ordinal)
+                && Trailers.SequenceEqual(other.Trailers, StringComparer.Ordinal);
+        }
+
+        public override int GetHashCode() => HashCode.Combine(Headers.Length, Trailers.Length);
+    }
+
+    private sealed class TestRandomFactory : IRandomFactory
+    {
+        public Random CreateRandomInstance() => Random.Shared;
+    }
+
+    private sealed class DerivedRequestHeaderValueTransform : RequestHeaderValueTransform
+    {
+        public DerivedRequestHeaderValueTransform()
+            : base("X-Derived", "base", append: false)
+        {
+        }
+
+        public override ValueTask ApplyAsync(RequestTransformContext context)
+        {
+            context.ProxyRequest.Headers.TryAddWithoutValidation("X-Derived", "derived");
+            return default;
+        }
+    }
+}


### PR DESCRIPTION
## Motivation

`StructuredTransformer.TransformRequestAsync` allocates a `RequestTransformContext` for every structured request-transform pipeline. That general context is necessary when transforms can mutate destination/path/query state, observe cancellation or request bodies, run asynchronously, or generate custom behavior. It is unnecessary when every request transform is an exact built-in header-only transform.

The removed object is 72 bytes per eligible request on the measured .NET 9 runtime.

## Change

At transformer construction, compute whether all request transforms are exact known built-in header transforms. Eligible pipelines execute the same transform array in the same order through an internal synchronous path using only:

- `HttpContext`
- `HttpRequestMessage`
- request-local `headersCopied` state

Exact type checks preserve derived-transform overrides. If any transform is path/query/body/context/custom/async/derived, the entire pipeline uses the existing `RequestTransformContext` path; there is no mixed-mode execution.

The eligible boundary covers original host, X-Forwarded For/Host/Proto/Prefix, RFC Forwarded, header remove/value/route-value, and header allow-list transforms. Tests now assert eligibility/fallback selection, `RequestHeadersAllowed` ordering and `HeadersCopied` transitions, original-host and route-value behavior, derived fallback, and that every allowlisted type overrides the internal fast-path method.

## BenchmarkDotNet

EgorBot does not support YARP. Its official README describes a service for `dotnet/runtime`, and the runtime performance skill lists only `dotnet/runtime` and `EgorBot/runtime-utils`. A portable BenchmarkDotNet harness is therefore the pending campaign-policy substitute.

Exact comparison:

- Parent: `49b23da6d8b0e9df47abf45d7755173f84670941`
- Final: `43911dfd95adf7bd45e2d7cbcb768a24c8c14a18`
- BenchmarkDotNet 0.15.8 / .NET 9.0.2
- macOS 26.5, Apple M5 Pro, Arm64
- `Job.ShortRun`, MemoryDiagnoser, 3 measured iterations, 3 warmups, one launch
- two isolated copies of the same harness, each directly referencing one exact-SHA DLL
- 0 and 50 extra request headers

Allocation is the primary metric. The two isolated runs are sequential, so timing is retained only as supporting evidence and no latency claim is made.

| Capability | Scenarios | Cells | Allocation delta |
|---|---|---:|---:|
| Eligible built-ins | default, original-host, X-Forwarded, Forwarded, header remove/value/route-value/allow-list, representative multi-header pipeline, response-header pipeline with built-in request handling | 20 | **-72 B/op in every cell** |
| General fallback/control | direct, path/query, mixed built-in + path/query, custom sync, custom async, custom context mutation, custom body observation, derived built-in | 16 | **0 B/op in every cell** |

Representative exact values:

| Scenario | Headers | Parent | Final | Delta |
|---|---:|---:|---:|---:|
| Default X-Forwarded | 0 | 2,464 B | 2,392 B | **-72 B** |
| Default X-Forwarded | 50 | 7,528 B | 7,456 B | **-72 B** |
| Request header set/append/remove | 0 | 3,360 B | 3,288 B | **-72 B** |
| Header allow-list | 50 | 1,304 B | 1,232 B | **-72 B** |
| Mixed headers + path/query | 0 | 5,840 B | 5,840 B | 0 B |
| Custom async | 50 | 8,160 B | 8,160 B | 0 B |
| Derived built-in | 0 | 3,112 B | 3,112 B | 0 B |

A separate exact-SHA Kestrel campaign ran 96 interleaved parent/final processes across default, mixed path/query, custom async, and body-observing pipelines; H1/H2; 0/50 extra headers; 10,000 requests after 1,000 warmups; concurrency 64. All requests completed successfully. Process-wide allocation/throughput includes client, proxy, backend, and thread-pool noise, so it is realistic functional evidence rather than a precise performance claim.

Evidence manifests:

- BDN: `/Users/artl/.copilot/session-state/294ad512-dbe2-42ad-8a82-c528f296fdb3/files/readiness-bdn-runs` (`SHA256SUMS` hash `1f18efc3277968b55f6178830a1c6a3d39a5b555c6b03bba2d85325123132150`)
- Kestrel: `/Users/artl/.copilot/session-state/294ad512-dbe2-42ad-8a82-c528f296fdb3/files/readiness-e2e` (`SHA256SUMS` hash `4aebaf19d23a4a843898486a6e2ba500315481b3604931b07d29fb9a2bd467e9`)

## Validation

- Fast-path differential tests: 30 passed across net8.0/net9.0
- All transform tests: 1,080 passed
- Full solution build: 0 warnings, 0 errors
- Full solution tests: 4,729 total; 4,657 passed; 72 skipped; 0 failed
- CI: green on Ubuntu, Windows, macOS, Docker build, markdown lint, and CLA
- Review threads: none
- Skeptical capability-boundary review: no correctness issue; the identified eligibility/allow-list/override guard gaps were added as tests

## Risks and limits

- The benefit is deliberately narrow: one non-eligible transform sends the whole pipeline through the existing general path.
- Exact-type allowlisting is maintenance-sensitive; tests now prove eligible pipelines select the fast path and all allowlisted types implement it.
- The fast path relies on eligible transforms remaining synchronous, header-only, unable to generate responses, and unable to mutate path/query/destination or observe cancellation/body state.
- The gain is deterministic but modest: 72 B/request. BDN timing and Kestrel throughput are noisy; no CPU/throughput improvement is claimed.
- EgorBot cannot provide YARP lab coverage. The portable BDN harness is ready for a future cross-platform campaign, but the reported execution is local macOS Arm64.

## AI disclosure

Implementation, tests, benchmark harnesses, evidence analysis, and this PR text were prepared with GitHub Copilot assistance and manually validated.