### PR TITLE
Reduce session-affinity async allocations

### DIFF
--- a/src/ReverseProxy/SessionAffinity/SessionAffinityMiddleware.cs
+++ b/src/ReverseProxy/SessionAffinity/SessionAffinityMiddleware.cs
@@ -4,6 +4,8 @@
 using System;
 using System.Collections.Frozen;
 using System.Collections.Generic;
+using System.Diagnostics;
+using System.Runtime.ExceptionServices;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Logging;
@@ -54,14 +56,54 @@ internal sealed class SessionAffinityMiddleware
         return InvokeInternal(context, proxyFeature, config);
     }
 
-    private async Task InvokeInternal(HttpContext context, IReverseProxyFeature proxyFeature, SessionAffinityConfig config)
+    private Task InvokeInternal(HttpContext context, IReverseProxyFeature proxyFeature, SessionAffinityConfig config)
+    {
+        try
+        {
+            return InvokeInternalCore(context, proxyFeature, config);
+        }
+        catch (Exception ex)
+        {
+            return CaptureException(ex);
+        }
+    }
+
+    private Task InvokeInternalCore(HttpContext context, IReverseProxyFeature proxyFeature, SessionAffinityConfig config)
     {
         var destinations = proxyFeature.AvailableDestinations;
         var cluster = proxyFeature.Route.Cluster!;
 
         var policy = _sessionAffinityPolicies.GetRequiredServiceById(config.Policy, SessionAffinityConstants.Policies.HashCookie);
-        var affinityResult = await policy.FindAffinitizedDestinationsAsync(context, cluster, config, destinations, context.RequestAborted);
+        var affinityResultTask = policy.FindAffinitizedDestinationsAsync(context, cluster, config, destinations, context.RequestAborted);
 
+        if (!affinityResultTask.IsCompletedSuccessfully)
+        {
+            return AwaitAffinityResult(affinityResultTask, context, proxyFeature, config, cluster, policy);
+        }
+
+        return HandleAffinityResult(context, proxyFeature, config, cluster, policy, affinityResultTask.Result);
+    }
+
+    private async Task AwaitAffinityResult(
+        ValueTask<AffinityResult> affinityResultTask,
+        HttpContext context,
+        IReverseProxyFeature proxyFeature,
+        SessionAffinityConfig config,
+        ClusterState cluster,
+        ISessionAffinityPolicy policy)
+    {
+        var affinityResult = await affinityResultTask;
+        await HandleAffinityResult(context, proxyFeature, config, cluster, policy, affinityResult);
+    }
+
+    private Task HandleAffinityResult(
+        HttpContext context,
+        IReverseProxyFeature proxyFeature,
+        SessionAffinityConfig config,
+        ClusterState cluster,
+        ISessionAffinityPolicy policy,
+        AffinityResult affinityResult)
+    {
         // Used for Distributed Tracing as part of Open Telemetry, null if there are no listeners
         var activity = context.GetYarpActivity();
         activity?.SetTag("proxy.session_affinity.policy", policy.Name);
@@ -79,26 +121,56 @@ internal sealed class SessionAffinityMiddleware
             case AffinityStatus.DestinationNotFound:
 
                 var failurePolicy = _affinityFailurePolicies.GetRequiredServiceById(config.FailurePolicy, SessionAffinityConstants.FailurePolicies.Redistribute);
-                var keepProcessing = await failurePolicy.Handle(context, proxyFeature.Route.Cluster!, affinityResult.Status);
-
-                if (!keepProcessing)
+                var failureTask = failurePolicy.Handle(context, cluster, affinityResult.Status);
+                if (!failureTask.IsCompletedSuccessfully)
                 {
-                    // Policy reported the failure is unrecoverable and took the full responsibility for its handling,
-                    // so we simply stop processing.
-                    Log.AffinityResolutionFailedForCluster(_logger, cluster.ClusterId);
-                    activity?.SetTag("proxy.session_affinity.status", "failed");
-                    return;
+                    return AwaitFailurePolicy(failureTask, context, cluster, failurePolicy, activity);
                 }
 
-                Log.AffinityResolutionFailureWasHandledProcessingWillBeContinued(_logger, cluster.ClusterId, failurePolicy.Name);
-                activity?.SetTag("proxy.session_affinity.status", "recovered");
-
-                break;
+                return HandleFailurePolicyResult(context, cluster, failurePolicy, activity, failureTask.Result);
             default:
                 throw new NotSupportedException($"Affinity status '{affinityResult.Status}' is not supported.");
         }
 
-        await _next(context);
+        return _next(context) ?? throw new NullReferenceException();
+    }
+
+    private async Task AwaitFailurePolicy(
+        Task<bool> failureTask,
+        HttpContext context,
+        ClusterState cluster,
+        IAffinityFailurePolicy failurePolicy,
+        Activity? activity)
+    {
+        var keepProcessing = await failureTask;
+        await HandleFailurePolicyResult(context, cluster, failurePolicy, activity, keepProcessing);
+    }
+
+    private Task HandleFailurePolicyResult(
+        HttpContext context,
+        ClusterState cluster,
+        IAffinityFailurePolicy failurePolicy,
+        Activity? activity,
+        bool keepProcessing)
+    {
+        if (!keepProcessing)
+        {
+            // Policy reported the failure is unrecoverable and took the full responsibility for its handling,
+            // so we simply stop processing.
+            Log.AffinityResolutionFailedForCluster(_logger, cluster.ClusterId);
+            activity?.SetTag("proxy.session_affinity.status", "failed");
+            return Task.CompletedTask;
+        }
+
+        Log.AffinityResolutionFailureWasHandledProcessingWillBeContinued(_logger, cluster.ClusterId, failurePolicy.Name);
+        activity?.SetTag("proxy.session_affinity.status", "recovered");
+        return _next(context) ?? throw new NullReferenceException();
+    }
+
+    private static async Task CaptureException(Exception exception)
+    {
+        await Task.CompletedTask;
+        ExceptionDispatchInfo.Capture(exception).Throw();
     }
 
     private static class Log

--- a/test/ReverseProxy.Tests/SessionAffinity/CookieSessionAffinityPolicyTests.cs
+++ b/test/ReverseProxy.Tests/SessionAffinity/CookieSessionAffinityPolicyTests.cs
@@ -122,6 +122,25 @@ public class CookieSessionAffinityPolicyTests
         Assert.False(context.Response.Headers.ContainsKey("Cookie"));
     }
 
+    [Theory]
+    [InlineData("QQ==", AffinityStatus.OK)]
+    [InlineData("QQ%3D%3D", AffinityStatus.OK)]
+    public void FindAffinitizedDestination_CookieValueIsUnescaped(string cookieValue, AffinityStatus expectedStatus)
+    {
+        var policy = new CookieSessionAffinityPolicy(
+            AffinityTestHelper.GetDataProtector().Object,
+            new TestTimeProvider(),
+            AffinityTestHelper.GetLogger<CookieSessionAffinityPolicy>().Object);
+        var destination = new DestinationState("A");
+        var context = new DefaultHttpContext();
+        context.Request.Headers.Cookie = $"{_config.AffinityKeyName}={cookieValue}";
+
+        var result = policy.FindAffinitizedDestinations(context, new ClusterState("cluster"), _config, new[] { destination });
+
+        Assert.Equal(expectedStatus, result.Status);
+        Assert.Same(expectedStatus == AffinityStatus.OK ? destination : null, result.Destinations?[0]);
+    }
+
     private string[] GetCookieWithAffinity(DestinationState affinitizedDestination)
     {
         return new[] { $"Some-Cookie=ZZZ", $"{_config.AffinityKeyName}={affinitizedDestination.DestinationId.ToUTF8BytesInBase64()}" };

--- a/test/ReverseProxy.Tests/SessionAffinity/CustomHeaderSessionAffinityPolicyTests.cs
+++ b/test/ReverseProxy.Tests/SessionAffinity/CustomHeaderSessionAffinityPolicyTests.cs
@@ -87,4 +87,20 @@ public class CustomHeaderSessionAffinityPolicyTests
 
         Assert.False(context.Response.Headers.ContainsKey(AffinityHeaderName));
     }
+
+    [Fact]
+    public void FindAffinitizedDestination_DuplicateHeaderValues_AreRejectedAsAmbiguous()
+    {
+        var policy = new CustomHeaderSessionAffinityPolicy(
+            AffinityTestHelper.GetDataProtector().Object,
+            AffinityTestHelper.GetLogger<CustomHeaderSessionAffinityPolicy>().Object);
+        var context = new DefaultHttpContext();
+        context.Request.Headers.Append(AffinityHeaderName, _destinations[0].DestinationId.ToUTF8BytesInBase64());
+        context.Request.Headers.Append(AffinityHeaderName, _destinations[1].DestinationId.ToUTF8BytesInBase64());
+
+        var result = policy.FindAffinitizedDestinations(context, new ClusterState("cluster"), _defaultOptions, _destinations);
+
+        Assert.Equal(AffinityStatus.AffinityKeyExtractionFailed, result.Status);
+        Assert.Null(result.Destinations);
+    }
 }

--- a/test/ReverseProxy.Tests/SessionAffinity/HashCookieSessionAffinityPolicyTests.cs
+++ b/test/ReverseProxy.Tests/SessionAffinity/HashCookieSessionAffinityPolicyTests.cs
@@ -4,7 +4,9 @@
 using System;
 using System.Collections.Generic;
 using System.IO.Hashing;
+using System.Linq;
 using System.Text;
+using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Logging.Abstractions;
 using Xunit;
@@ -120,6 +122,88 @@ public class HashCookieSessionAffinityPolicyTests
         policy.AffinitizeResponse(context, cluster, _config, affinitizedDestination);
 
         Assert.False(context.Response.Headers.ContainsKey("Cookie"));
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void FindAffinitizedDestination_DuplicateAffinityCookie_LastValueWins(bool validValueLast)
+    {
+        var policy = new HashCookieSessionAffinityPolicy(
+            new TestTimeProvider(),
+            NullLogger<HashCookieSessionAffinityPolicy>.Instance);
+        var validCookie = GetCookieWithAffinity(_destinations[1])[1];
+        var staleCookie = $"{_config.AffinityKeyName}=0000000000000000";
+        var context = new DefaultHttpContext();
+        context.Request.Headers.Cookie = validValueLast
+            ? $"{staleCookie}; {validCookie}"
+            : $"{validCookie}; {staleCookie}";
+
+        var result = policy.FindAffinitizedDestinations(context, new ClusterState("cluster"), _config, _destinations);
+
+        Assert.Equal(validValueLast ? AffinityStatus.OK : AffinityStatus.DestinationNotFound, result.Status);
+        Assert.Same(validValueLast ? _destinations[1] : null, result.Destinations?.Single());
+    }
+
+    [Theory]
+    [InlineData("HTTP/1.1")]
+    [InlineData("HTTP/2")]
+    public void FindAffinitizedDestination_ProtocolDoesNotChangeResolution(string protocol)
+    {
+        var policy = new HashCookieSessionAffinityPolicy(
+            new TestTimeProvider(),
+            NullLogger<HashCookieSessionAffinityPolicy>.Instance);
+        var context = new DefaultHttpContext();
+        context.Request.Protocol = protocol;
+        context.Request.Headers.Cookie = GetCookieWithAffinity(_destinations[1]);
+
+        var result = policy.FindAffinitizedDestinations(context, new ClusterState("cluster"), _config, _destinations);
+
+        Assert.Equal(AffinityStatus.OK, result.Status);
+        Assert.Same(_destinations[1], result.Destinations?.Single());
+    }
+
+    [Fact]
+    public void FindAffinitizedDestination_UsesCurrentDestinationSnapshot()
+    {
+        var policy = new HashCookieSessionAffinityPolicy(
+            new TestTimeProvider(),
+            NullLogger<HashCookieSessionAffinityPolicy>.Instance);
+        var context = new DefaultHttpContext();
+        context.Request.Headers.Cookie = GetCookieWithAffinity(_destinations[1]);
+        var cluster = new ClusterState("cluster");
+
+        var beforeChurn = policy.FindAffinitizedDestinations(context, cluster, _config, _destinations);
+        var afterRemoval = policy.FindAffinitizedDestinations(context, cluster, _config, new[] { _destinations[0], _destinations[2] });
+        var replacement = new DestinationState(_destinations[1].DestinationId);
+        var afterReplacement = policy.FindAffinitizedDestinations(context, cluster, _config, new[] { replacement });
+
+        Assert.Equal(AffinityStatus.OK, beforeChurn.Status);
+        Assert.Equal(AffinityStatus.DestinationNotFound, afterRemoval.Status);
+        Assert.Equal(AffinityStatus.OK, afterReplacement.Status);
+        Assert.Same(replacement, afterReplacement.Destinations?.Single());
+    }
+
+    [Fact]
+    public async Task FindAffinitizedDestination_ConcurrentRequestsRemainIsolated()
+    {
+        var policy = new HashCookieSessionAffinityPolicy(
+            new TestTimeProvider(),
+            NullLogger<HashCookieSessionAffinityPolicy>.Instance);
+        var cookie = GetCookieWithAffinity(_destinations[1]);
+
+        var results = await Task.WhenAll(Enumerable.Range(0, 256).Select(_ => Task.Run(() =>
+        {
+            var context = new DefaultHttpContext();
+            context.Request.Headers.Cookie = cookie;
+            return policy.FindAffinitizedDestinations(context, new ClusterState("cluster"), _config, _destinations);
+        })));
+
+        Assert.All(results, result =>
+        {
+            Assert.Equal(AffinityStatus.OK, result.Status);
+            Assert.Same(_destinations[1], result.Destinations?.Single());
+        });
     }
 
     private string[] GetCookieWithAffinity(DestinationState affinitizedDestination)

--- a/test/ReverseProxy.Tests/SessionAffinity/SessionAffinityDifferentialTests.cs
+++ b/test/ReverseProxy.Tests/SessionAffinity/SessionAffinityDifferentialTests.cs
@@ -187,6 +187,24 @@ public class SessionAffinityDifferentialTests
     }
 
     [Fact]
+    public async Task Invoke_AsyncCanceledProviderProducesCanceledTask()
+    {
+        using var cancellation = new CancellationTokenSource();
+        cancellation.Cancel();
+        var (_, _, context) = CreateContext("HTTP/1.1");
+        var middleware = new SessionAffinityMiddleware(
+            _ => Task.CompletedTask,
+            new ISessionAffinityPolicy[] { new AsyncCanceledAffinityPolicy() },
+            Array.Empty<IAffinityFailurePolicy>(),
+            NullLogger<SessionAffinityMiddleware>.Instance);
+
+        var invokeTask = middleware.Invoke(context);
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => invokeTask);
+        Assert.True(invokeTask.IsCanceled);
+    }
+
+    [Fact]
     public async Task Invoke_NullTaskFromNextIsCapturedInReturnedTask()
     {
         var (_, destinations, context) = CreateContext("HTTP/1.1");
@@ -387,6 +405,39 @@ public class SessionAffinityDifferentialTests
         {
             await Task.Yield();
             throw _exception;
+        }
+    }
+
+    private sealed class AsyncCanceledAffinityPolicy : ISessionAffinityPolicy
+    {
+        public string Name => "Custom";
+
+        public AffinityResult FindAffinitizedDestinations(
+            HttpContext context,
+            ClusterState cluster,
+            SessionAffinityConfig config,
+            IReadOnlyList<DestinationState> destinations)
+        {
+            throw new NotSupportedException();
+        }
+
+        public async ValueTask<AffinityResult> FindAffinitizedDestinationsAsync(
+            HttpContext context,
+            ClusterState cluster,
+            SessionAffinityConfig config,
+            IReadOnlyList<DestinationState> destinations,
+            CancellationToken cancellationToken)
+        {
+            await Task.Yield();
+            throw new OperationCanceledException(cancellationToken);
+        }
+
+        public void AffinitizeResponse(
+            HttpContext context,
+            ClusterState cluster,
+            SessionAffinityConfig config,
+            DestinationState destination)
+        {
         }
     }
 

--- a/test/ReverseProxy.Tests/SessionAffinity/SessionAffinityDifferentialTests.cs
+++ b/test/ReverseProxy.Tests/SessionAffinity/SessionAffinityDifferentialTests.cs
@@ -1,0 +1,417 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+using Yarp.ReverseProxy.Configuration;
+using Yarp.ReverseProxy.Forwarder;
+using Yarp.ReverseProxy.Model;
+
+namespace Yarp.ReverseProxy.SessionAffinity.Tests;
+
+public class SessionAffinityDifferentialTests
+{
+    [Theory]
+    [InlineData("HTTP/1.1", false, false)]
+    [InlineData("HTTP/1.1", true, true)]
+    [InlineData("HTTP/2", false, true)]
+    [InlineData("HTTP/2", true, false)]
+    public async Task Invoke_PreservesProviderNextOrderingAndReassignment(string protocol, bool asyncProvider, bool asyncNext)
+    {
+        var events = new List<string>();
+        var (cluster, destinations, context) = CreateContext(protocol);
+        var policy = new TestAffinityPolicy("Custom", AffinityStatus.OK, destinations[1], asyncProvider, events);
+        var middleware = new SessionAffinityMiddleware(async httpContext =>
+        {
+            events.Add("next-start");
+            Assert.Same(destinations[1], httpContext.GetReverseProxyFeature().AvailableDestinations.Single());
+            if (asyncNext)
+            {
+                await Task.Yield();
+            }
+            events.Add("next-end");
+        }, new[] { policy }, Array.Empty<IAffinityFailurePolicy>(), NullLogger<SessionAffinityMiddleware>.Instance);
+
+        await middleware.Invoke(context);
+
+        Assert.Equal(new[] { "provider-start", "provider-end", "next-start", "next-end" }, events);
+        Assert.Same(cluster.Model, context.GetReverseProxyFeature().Cluster);
+    }
+
+    [Theory]
+    [InlineData(false, false, true)]
+    [InlineData(false, true, true)]
+    [InlineData(true, false, false)]
+    [InlineData(true, true, false)]
+    public async Task Invoke_PreservesFailurePolicyOrdering(bool asyncProvider, bool asyncFailurePolicy, bool keepProcessing)
+    {
+        var events = new List<string>();
+        var (_, _, context) = CreateContext("HTTP/1.1");
+        var policy = new TestAffinityPolicy("Custom", AffinityStatus.DestinationNotFound, null, asyncProvider, events);
+        var failurePolicy = new TestFailurePolicy("CustomFailure", keepProcessing, asyncFailurePolicy, events);
+        var middleware = new SessionAffinityMiddleware(httpContext =>
+        {
+            events.Add("next");
+            return Task.CompletedTask;
+        }, new[] { policy }, new[] { failurePolicy }, NullLogger<SessionAffinityMiddleware>.Instance);
+
+        await middleware.Invoke(context);
+
+        var expected = keepProcessing
+            ? new[] { "provider-start", "provider-end", "failure-start", "failure-end", "next" }
+            : new[] { "provider-start", "provider-end", "failure-start", "failure-end" };
+        Assert.Equal(expected, events);
+        Assert.Equal(keepProcessing ? StatusCodes.Status200OK : StatusCodes.Status503ServiceUnavailable, context.Response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Invoke_ConcurrentRequestsKeepDestinationStateIsolated()
+    {
+        var observed = new ConcurrentBag<DestinationState>();
+        var policy = new TestAffinityPolicy("Custom", AffinityStatus.OK, destination: null, isAsync: false, events: null);
+        var middleware = new SessionAffinityMiddleware(context =>
+        {
+            observed.Add(context.GetReverseProxyFeature().AvailableDestinations.Single());
+            return Task.CompletedTask;
+        }, new[] { policy }, Array.Empty<IAffinityFailurePolicy>(), NullLogger<SessionAffinityMiddleware>.Instance);
+
+        var contexts = Enumerable.Range(0, 256).Select(index =>
+        {
+            var (_, destinations, context) = CreateContext(index % 2 == 0 ? "HTTP/1.1" : "HTTP/2");
+            policy.SetDestination(context, destinations[index % destinations.Count]);
+            return context;
+        }).ToArray();
+
+        await Task.WhenAll(contexts.Select(context => Task.Run(() => middleware.Invoke(context))));
+
+        Assert.Equal(contexts.Length, observed.Count);
+        Assert.All(contexts, context =>
+        {
+            var expected = policy.GetDestination(context);
+            Assert.Same(expected, context.GetReverseProxyFeature().AvailableDestinations.Single());
+        });
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task Invoke_ProviderExceptionsAreCapturedInReturnedTask(bool isAsync)
+    {
+        var expected = new InvalidOperationException("provider failure");
+        var (_, _, context) = CreateContext("HTTP/1.1");
+        var middleware = new SessionAffinityMiddleware(
+            _ => Task.CompletedTask,
+            new ISessionAffinityPolicy[] { new ThrowingAffinityPolicy(expected, isAsync) },
+            Array.Empty<IAffinityFailurePolicy>(),
+            NullLogger<SessionAffinityMiddleware>.Instance);
+
+        var invokeTask = middleware.Invoke(context);
+
+        var actual = await Assert.ThrowsAsync<InvalidOperationException>(() => invokeTask);
+        Assert.Same(expected, actual);
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task Invoke_FailurePolicyExceptionsAreCapturedInReturnedTask(bool isAsync)
+    {
+        var expected = new InvalidOperationException("failure policy failure");
+        var (_, _, context) = CreateContext("HTTP/1.1");
+        var policy = new TestAffinityPolicy("Custom", AffinityStatus.DestinationNotFound, null, isAsync: false, events: null);
+        var middleware = new SessionAffinityMiddleware(
+            _ => Task.CompletedTask,
+            new[] { policy },
+            new IAffinityFailurePolicy[] { new ThrowingFailurePolicy(expected, isAsync) },
+            NullLogger<SessionAffinityMiddleware>.Instance);
+
+        var invokeTask = middleware.Invoke(context);
+
+        var actual = await Assert.ThrowsAsync<InvalidOperationException>(() => invokeTask);
+        Assert.Same(expected, actual);
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task Invoke_NextExceptionsAreCapturedInReturnedTask(bool isAsync)
+    {
+        var expected = new InvalidOperationException("next failure");
+        var (_, destinations, context) = CreateContext("HTTP/1.1");
+        var policy = new TestAffinityPolicy("Custom", AffinityStatus.OK, destinations[0], isAsync: false, events: null);
+        RequestDelegate next = isAsync
+            ? async _ =>
+            {
+                await Task.Yield();
+                throw expected;
+            }
+            : _ => throw expected;
+        var middleware = new SessionAffinityMiddleware(
+            next,
+            new[] { policy },
+            Array.Empty<IAffinityFailurePolicy>(),
+            NullLogger<SessionAffinityMiddleware>.Instance);
+
+        var invokeTask = middleware.Invoke(context);
+
+        var actual = await Assert.ThrowsAsync<InvalidOperationException>(() => invokeTask);
+        Assert.Same(expected, actual);
+    }
+
+    [Fact]
+    public async Task Invoke_CanceledRequestProducesCanceledTask()
+    {
+        using var cancellation = new CancellationTokenSource();
+        cancellation.Cancel();
+        var (_, destinations, context) = CreateContext("HTTP/1.1");
+        context.RequestAborted = cancellation.Token;
+        var policy = new TestAffinityPolicy("Custom", AffinityStatus.OK, destinations[0], isAsync: false, events: null);
+        var middleware = new SessionAffinityMiddleware(
+            _ => Task.CompletedTask,
+            new[] { policy },
+            Array.Empty<IAffinityFailurePolicy>(),
+            NullLogger<SessionAffinityMiddleware>.Instance);
+
+        var invokeTask = middleware.Invoke(context);
+
+        Assert.True(invokeTask.IsCanceled);
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => invokeTask);
+    }
+
+    [Fact]
+    public async Task Invoke_NullTaskFromNextIsCapturedInReturnedTask()
+    {
+        var (_, destinations, context) = CreateContext("HTTP/1.1");
+        var policy = new TestAffinityPolicy("Custom", AffinityStatus.OK, destinations[0], isAsync: false, events: null);
+        var middleware = new SessionAffinityMiddleware(
+            _ => null!,
+            new[] { policy },
+            Array.Empty<IAffinityFailurePolicy>(),
+            NullLogger<SessionAffinityMiddleware>.Instance);
+
+        var invokeTask = middleware.Invoke(context);
+
+        await Assert.ThrowsAsync<NullReferenceException>(() => invokeTask);
+    }
+
+    private static (ClusterState Cluster, IReadOnlyList<DestinationState> Destinations, DefaultHttpContext Context) CreateContext(string protocol)
+    {
+        var cluster = new ClusterState("cluster");
+        var destinations = new[] { new DestinationState("dest-A"), new DestinationState("dest-B"), new DestinationState("dest-C") };
+        var config = new ClusterConfig
+        {
+            ClusterId = cluster.ClusterId,
+            SessionAffinity = new SessionAffinityConfig
+            {
+                Enabled = true,
+                Policy = "Custom",
+                FailurePolicy = "CustomFailure",
+                AffinityKeyName = "Affinity",
+            },
+        };
+        cluster.Model = new ClusterModel(config, new HttpMessageInvoker(new HttpClientHandler()));
+        cluster.DestinationsState = new ClusterDestinationsState(destinations, destinations);
+
+        var context = new DefaultHttpContext();
+        context.Request.Protocol = protocol;
+        context.Features.Set<IReverseProxyFeature>(new ReverseProxyFeature
+        {
+            Route = new RouteModel(new RouteConfig(), cluster, HttpTransformer.Default),
+            Cluster = cluster.Model,
+            AllDestinations = destinations,
+            AvailableDestinations = destinations,
+        });
+        return (cluster, destinations, context);
+    }
+
+    private sealed class TestAffinityPolicy : ISessionAffinityPolicy
+    {
+        private readonly AffinityStatus _status;
+        private readonly DestinationState _destination;
+        private readonly bool _isAsync;
+        private readonly List<string> _events;
+        private readonly ConcurrentDictionary<HttpContext, DestinationState> _destinations = new();
+
+        public TestAffinityPolicy(string name, AffinityStatus status, DestinationState destination, bool isAsync, List<string> events)
+        {
+            Name = name;
+            _status = status;
+            _destination = destination;
+            _isAsync = isAsync;
+            _events = events;
+        }
+
+        public string Name { get; }
+
+        public AffinityResult FindAffinitizedDestinations(
+            HttpContext context,
+            ClusterState cluster,
+            SessionAffinityConfig config,
+            IReadOnlyList<DestinationState> destinations)
+        {
+            return Complete(context);
+        }
+
+        public ValueTask<AffinityResult> FindAffinitizedDestinationsAsync(
+            HttpContext context,
+            ClusterState cluster,
+            SessionAffinityConfig config,
+            IReadOnlyList<DestinationState> destinations,
+            CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            _events?.Add("provider-start");
+            return _isAsync ? CompleteAsync(context) : new ValueTask<AffinityResult>(CompleteAfterStart(context));
+        }
+
+        public void AffinitizeResponse(
+            HttpContext context,
+            ClusterState cluster,
+            SessionAffinityConfig config,
+            DestinationState destination)
+        {
+        }
+
+        public void SetDestination(HttpContext context, DestinationState destination) => _destinations[context] = destination;
+
+        public DestinationState GetDestination(HttpContext context) => _destinations[context];
+
+        private async ValueTask<AffinityResult> CompleteAsync(HttpContext context)
+        {
+            await Task.Yield();
+            return CompleteAfterStart(context);
+        }
+
+        private AffinityResult Complete(HttpContext context)
+        {
+            _events?.Add("provider-start");
+            return CompleteAfterStart(context);
+        }
+
+        private AffinityResult CompleteAfterStart(HttpContext context)
+        {
+            _events?.Add("provider-end");
+            var destination = _destination ?? _destinations.GetValueOrDefault(context);
+            return new AffinityResult(destination, _status);
+        }
+    }
+
+    private sealed class TestFailurePolicy : IAffinityFailurePolicy
+    {
+        private readonly bool _keepProcessing;
+        private readonly bool _isAsync;
+        private readonly List<string> _events;
+
+        public TestFailurePolicy(string name, bool keepProcessing, bool isAsync, List<string> events)
+        {
+            Name = name;
+            _keepProcessing = keepProcessing;
+            _isAsync = isAsync;
+            _events = events;
+        }
+
+        public string Name { get; }
+
+        public Task<bool> Handle(HttpContext context, ClusterState cluster, AffinityStatus affinityStatus)
+        {
+            _events.Add("failure-start");
+            if (!_keepProcessing)
+            {
+                context.Response.StatusCode = StatusCodes.Status503ServiceUnavailable;
+            }
+            return _isAsync ? CompleteAsync() : Task.FromResult(Complete());
+        }
+
+        private async Task<bool> CompleteAsync()
+        {
+            await Task.Yield();
+            return Complete();
+        }
+
+        private bool Complete()
+        {
+            _events.Add("failure-end");
+            return _keepProcessing;
+        }
+    }
+
+    private sealed class ThrowingAffinityPolicy : ISessionAffinityPolicy
+    {
+        private readonly Exception _exception;
+        private readonly bool _isAsync;
+
+        public ThrowingAffinityPolicy(Exception exception, bool isAsync)
+        {
+            _exception = exception;
+            _isAsync = isAsync;
+        }
+
+        public string Name => "Custom";
+
+        public AffinityResult FindAffinitizedDestinations(
+            HttpContext context,
+            ClusterState cluster,
+            SessionAffinityConfig config,
+            IReadOnlyList<DestinationState> destinations)
+        {
+            throw _exception;
+        }
+
+        public ValueTask<AffinityResult> FindAffinitizedDestinationsAsync(
+            HttpContext context,
+            ClusterState cluster,
+            SessionAffinityConfig config,
+            IReadOnlyList<DestinationState> destinations,
+            CancellationToken cancellationToken)
+        {
+            return _isAsync ? ThrowAsync() : throw _exception;
+        }
+
+        public void AffinitizeResponse(
+            HttpContext context,
+            ClusterState cluster,
+            SessionAffinityConfig config,
+            DestinationState destination)
+        {
+        }
+
+        private async ValueTask<AffinityResult> ThrowAsync()
+        {
+            await Task.Yield();
+            throw _exception;
+        }
+    }
+
+    private sealed class ThrowingFailurePolicy : IAffinityFailurePolicy
+    {
+        private readonly Exception _exception;
+        private readonly bool _isAsync;
+
+        public ThrowingFailurePolicy(Exception exception, bool isAsync)
+        {
+            _exception = exception;
+            _isAsync = isAsync;
+        }
+
+        public string Name => "CustomFailure";
+
+        public Task<bool> Handle(HttpContext context, ClusterState cluster, AffinityStatus affinityStatus)
+        {
+            return _isAsync ? ThrowAsync() : throw _exception;
+        }
+
+        private async Task<bool> ThrowAsync()
+        {
+            await Task.Yield();
+            throw _exception;
+        }
+    }
+}


### PR DESCRIPTION
## Summary

`SessionAffinityMiddleware` currently keeps its own async state machine alive while awaiting the downstream proxy pipeline. Built-in affinity policies usually complete synchronously, while forwarding normally suspends.

This change handles synchronously completed affinity results inline and returns the downstream task directly. It avoids one middleware async-frame allocation without changing the public policy interfaces.

**Scope:** this only benefits affinity-enabled requests where the affinity/failure policy completes synchronously and downstream completes asynchronously. Affinity-disabled requests, immediate failures that do not call downstream, and genuinely asynchronous custom policies do not receive the same reduction.

This PR remains draft.

## BenchmarkDotNet results

EgorBot does not appear to be enabled for `dotnet/yarp`: there is no repository workflow, configuration, or prior invocation in YARP history. As a cross-platform substitute, I ran BenchmarkDotNet 0.15.8 locally with separate exact-parent and exact-final jobs:

- Parent: `49b23da6d8b0e9df47abf45d7755173f84670941`
- Product change: `69457515f0f0a9e5b99d83d9384360b1889a0366`
- PR head: `d3627b95676a7f28c812616e4bb7ca652e2916a6` (test-only follow-up; product source is unchanged)
- BDN environment: macOS Tahoe 26.5.2 (25F84), Darwin 25.5.0, Apple M5 Pro arm64, .NET SDK `11.0.100-preview.5.26227.104`, runtime .NET 9.0.2
- Comparison: BDN job baseline/current DLL references, apples-to-apples invocation counts, `MemoryDiagnoser`

### Component pipeline

| Scenario | Parent B/request | Final B/request | Delta |
|---|---:|---:|---:|
| Disabled, synchronous downstream | 1,552 | 1,552 | 0 |
| Disabled, forced-async downstream | 1,968 | 1,968 | 0 |
| Cookie hit, synchronous downstream | 2,288 | 2,288 | 0 |
| Cookie hit, forced-async downstream | 2,904 | 2,704 | **-200** |
| Cookie miss, forced-async downstream | 2,248 | 2,048 | **-200** |
| Stale cookie, forced-async downstream | 2,640 | 2,440 | **-200** |
| Async header-policy hit control | 2,464 | 2,472 | +8 |
| Async header-policy miss control | 2,368 | 2,376 | +8 |

The allocation reduction is limited to the synchronous-policy/async-downstream path. Synchronous downstream and disabled controls are unchanged. Genuinely asynchronous custom-policy controls show a small +8 B/request tradeoff.

### Real Kestrel proxy path

The BDN method sends a real loopback request through Kestrel, `MapReverseProxy`, and a Kestrel backend.

| Scenario | Parent B/request | Final B/request | Delta |
|---|---:|---:|---:|
| HTTP/1.1 disabled | 4,344 | 4,341 | -3 |
| HTTP/2 disabled | 5,971 | 5,967 | -4 |
| HTTP/1.1 cookie hit | 5,438 | 5,229 | **-209** |
| HTTP/2 cookie hit | 7,045 | 6,804 | **-241** |
| HTTP/1.1 cookie miss | 5,296 | 5,096 | **-200** |
| HTTP/2 cookie miss | 6,919 | 6,720 | **-199** |
| HTTP/1.1 stale cookie | 5,824 | 5,622 | **-202** |
| HTTP/2 stale cookie | 7,450 | 7,243 | **-207** |

Async header-policy controls varied from -14 to +40 B/request in the Kestrel run, consistent with no material allocation improvement for that path.

Timing was noisy and BDN's 5% equivalence test reported the main cookie and Kestrel comparisons as `Same`. **No throughput or latency improvement is claimed.** The supported result is the allocation reduction above.

### Allocation trace

Exact-binary EventPipe traces sampled the parent `SessionAffinityMiddleware.<InvokeInternal>` state-machine box 1,747 times on misses and 2,467 times on hits. Final hit/miss traces sampled it zero times. Disabled traces sampled it zero times on both sides.

## Correctness

Synchronous exceptions are converted back into returned tasks using `ExceptionDispatchInfo`, preserving the original async method behavior. Canceled operations remain canceled tasks. Faulted/canceled `ValueTask`s still take the await path, and each `ValueTask` is consumed once.

Tests cover:

- cookie/header hit, miss, invalid, and stale keys;
- destination reassignment and middleware ordering;
- synchronous and asynchronous custom policies/failure policies;
- exceptions from policies and downstream;
- cancellation before and after suspension;
- null downstream tasks, concurrency, and no double execution.

Validation:

- 2,000 ReverseProxy unit tests passed per target framework and configuration
- 75 affinity tests passed per target framework and configuration
- 269 functional tests per target framework: 235 passed, 34 expected skips, 0 failures
- Cross-platform CI passed at head `d3627b95676a7f28c812616e4bb7ca652e2916a6` / merge `34b835fa480590f04c2d9dbc6eacc533a7cc5093`: Windows (`NetCore-Public 529`), Ubuntu (`Azure Pipelines 146`), and macOS latest (`Azure Pipelines 56`); Docker, lint, and CLA checks also passed
- No unresolved review threads or comments

## Evidence and limitations

The standalone benchmark is a session artifact rather than a product-tree benchmark. It references the exact parent/final YARP DLLs and can run on any platform supported by BDN and YARP.

- BDN source/report manifest SHA-256: `3549b8ad0eb4f28d5355683c145ec3a7c9e0d63f63b277d2b8f8fd95261a9590`
- BDN evidence archive SHA-256: `1a7477d2de7f6d214ead3a45be68ed36cb00fbc189716bac6610a0daea4caaa6`
- Component full JSON SHA-256: `ae1c361dde8e58afb9535410beb56c7aff7ea497639234458da1c2b874b7b215`
- Kestrel full JSON SHA-256: `358cea3e7df9225f2967f244dcc075eab82351dcd805d549f217f1b87b055103`

Cookie parsing and `HttpContext.Items` allocations are unchanged. This PR removes only the additional session-affinity middleware async frame.
