### PR TITLE
Remove Publish-Build-Assets variable group from main

### DIFF
--- a/azure-pipelines-nonprod.yml
+++ b/azure-pipelines-nonprod.yml
@@ -77,7 +77,6 @@ extends:
               image: 1es-windows-2022
               os: windows
             variables:
-            - group: Publish-Build-Assets
             - name: _OfficialBuildArgs
               value: /p:DotNetSignType=$(_SignType)
                      /p:TeamName=$(_TeamName)

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -71,7 +71,6 @@ extends:
               image: 1es-windows-2022
               os: windows
             variables:
-            - group: Publish-Build-Assets
             - name: _OfficialBuildArgs
               value: /p:DotNetSignType=$(_SignType)
                      /p:TeamName=$(_TeamName)


### PR DESCRIPTION
Removes the repository-owned `Publish-Build-Assets` variable group import from:

- `azure-pipelines-nonprod.yml`
- `azure-pipelines.yml`

This is part of the tracked VG20 cleanup: https://dev.azure.com/dnceng/internal/_workitems/edit/12131