### PR TITLE
Update triple slash comments on QueryParameterMatchMode and HeaderMatchMode

### DIFF
--- a/src/ReverseProxy/Configuration/HeaderMatchMode.cs
+++ b/src/ReverseProxy/Configuration/HeaderMatchMode.cs
@@ -28,8 +28,8 @@ public enum HeaderMatchMode
     Contains,
 
     /// <summary>
-    /// The header must exist and the value must be non-empty.
     /// None of the headers with the given name may contain any of the match values, subject to case sensitivity settings.
+    /// The rule also matches if the header is missing or its value is empty.
     /// </summary>
     NotContains,
 
@@ -40,7 +40,7 @@ public enum HeaderMatchMode
     Exists,
 
     /// <summary>
-    /// The header must not exist.
+    /// The header must not exist, or its value must be empty.
     /// </summary>
     NotExists,
 }

--- a/src/ReverseProxy/Configuration/QueryParameterMatchMode.cs
+++ b/src/ReverseProxy/Configuration/QueryParameterMatchMode.cs
@@ -9,36 +9,29 @@ namespace Yarp.ReverseProxy.Configuration;
 public enum QueryParameterMatchMode
 {
     /// <summary>
-    /// Query string must match in its entirety,
-    /// Subject to case sensitivity settings.
-    /// Only single query parameter name supported. If there are multiple query parameters with the same name then the match fails.
+    /// Any of the values for the given query parameter must match in its entirety, subject to case sensitivity settings.
     /// </summary>
     Exact,
 
     /// <summary>
-    /// Query string key must be present and substring must match for each of the respective query string values.
-    /// Subject to case sensitivity settings.
-    /// Only single query parameter name supported. If there are multiple query parameters with the same name then the match fails.
+    /// Any of the values for the given query parameter must contain any of the match values, subject to case sensitivity settings.
     /// </summary>
     Contains,
 
     /// <summary>
-    /// Query string key must be present and value must not match for each of the respective query string values.
-    /// Subject to case sensitivity settings.
-    /// If there are multiple values then it needs to not contain ANY of the values 
-    /// Only single query parameter name supported. If there are multiple query parameters with the same name then the match fails.
+    /// None of the values for the given query parameter may contain any of the match values, subject to case sensitivity settings.
+    /// The rule also matches if the query parameter is missing or its value is empty.
     /// </summary>
     NotContains,
 
     /// <summary>
-    /// Query string key must be present and prefix must match for each of the respective query string values.
-    /// Subject to case sensitivity settings.
-    /// Only single query parameter name supported. If there are multiple query parameters with the same name then the match fails.
+    /// Any of the values for the given query parameter must match by prefix, subject to case sensitivity settings.
     /// </summary>
     Prefix,
 
     /// <summary>
-    /// Query string key must exist and contain any non-empty value.
+    /// The query parameter must exist and contain any non-empty value.
+    /// If the query string contains multiple values for that name, the rule will also match.
     /// </summary>
     Exists
 }


### PR DESCRIPTION
Follow-up to #2000, which updated these comments on `HeaderMatchMode` but left two gaps. Comments only, no behavior change.

### 1. `QueryParameterMatchMode` was not covered by #2000

#2000 removed *"Only single headers are supported. If there are multiple headers with the same name then the match fails."* from `HeaderMatchMode`, but the equivalent sentence is still on four members of `QueryParameterMatchMode`:

> Only single query parameter name supported. If there are multiple query parameters with the same name then the match fails.

`QueryParameterMatcherPolicy` iterates over every value bound to the name and matches if any of them matches, so a repeated name does not fail the match. This is already asserted by `QueryMatcherPolicyTests`:

```csharp
[InlineData("abc", QueryParameterMatchMode.Exact, true, "a;abc", true)]
```

which builds `?org-id=a&org-id=abc` and expects a match.

The same block also claims the value must match *"for each of the respective query string values"* on `Contains` and `Prefix`, where the matcher is an any-of.

### 2. `NotContains` and `NotExists` drifted again after #2260

`HeaderMatchMode.NotContains` currently opens with:

> The header must exist and the value must be non-empty.

That was accurate when #2000 was written, but the fix for #2260 deliberately made a missing or empty header match, and the comment was not updated. `QueryParameterMatchMode.NotContains` has the same stale *"key must be present"* claim.

`NotExists` says *"The header must not exist"*, while a header that is present with an empty value also matches.

Both behaviors are already pinned by `HeaderMatcherPolicyTests`:

```csharp
[InlineData(null, HeaderMatchMode.NotExists, true)]
[InlineData("", HeaderMatchMode.NotExists, true)]   // present but empty -> matches
[InlineData("abc", HeaderMatchMode.NotContains, false, null, true)]
[InlineData("abc", HeaderMatchMode.NotContains, false, "", true)]
```

### Observed on the shipped 2.3.0 package

| Route match | Comment predicts | Actual |
| --- | --- | --- |
| `NotContains` on `X-Client-Type`, header absent | no match | **match** |
| `NotContains` on `X-Client-Type`, header present but empty | no match | **match** |
| `NotExists` on `X-Client-Type`, header present but empty | no match | **match** |
| `Exact` on `env=prod`, request `?env=test&env=prod` | no match | **match** |

The wording added here follows the phrasing #2000 introduced for headers.

### Verification

`build.cmd -projects src\ReverseProxy\Yarp.ReverseProxy.csproj` succeeds with 0 warnings and 0 errors, and `build.cmd -test -projects test\ReverseProxy.Tests\Yarp.ReverseProxy.Tests.csproj` passes on both net8.0 and net9.0.

No test changes were needed: the existing tests already assert the behavior described here.
